### PR TITLE
change normalize method visibility

### DIFF
--- a/src/core/pdf-document/PDFDocumentFactory.ts
+++ b/src/core/pdf-document/PDFDocumentFactory.ts
@@ -90,7 +90,7 @@ class PDFDocumentFactory {
 
   // TODO: Need to throw out objects with "free" obj numbers...
   /** @hidden */
-  private static normalize = ({
+  protected static normalize = ({
     dictionaries,
     arrays,
     original: { body },


### PR DESCRIPTION
following #61 we need to be able to use normalize in subclasses of PDFDocumentFactory