### PR TITLE
Encode PDFString containing non-Latin characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pdf-lib",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Create and modify PDF files with JavaScript",
   "author": "Andrew Dillon <andrew.dillon.j@gmail.com>",
   "contributors": [
@@ -56,7 +56,8 @@
     "@pdf-lib/standard-fonts": "^0.0.4",
     "pako": "^1.0.10",
     "png-ts": "^0.0.3",
-    "tslib": "^1.10.0"
+    "tslib": "^1.10.0",
+    "utfx": "^1.0.1"
   },
   "devDependencies": {
     "@pdf-lib/fontkit": "^0.0.4",

--- a/src/core/objects/PDFString.ts
+++ b/src/core/objects/PDFString.ts
@@ -1,37 +1,51 @@
 import PDFObject from 'src/core/objects/PDFObject';
-import CharCodes from 'src/core/syntax/CharCodes';
-import { copyStringIntoBuffer } from 'src/utils';
+import { copyStringIntoBuffer, toHexStringOfMinLength } from 'src/utils';
+import utfx = require('utfx');
 
 class PDFString extends PDFObject {
   // The PDF spec allows newlines and parens to appear directly within a literal
   // string. These character _may_ be escaped. But they do not _have_ to be. So
   // for simplicity, we will not bother escaping them.
-  static of = (value: string) => new PDFString(value);
+  static of = (value: string) => new PDFString(value, false);
 
   private readonly value: string;
 
-  private constructor(value: string) {
+  private constructor(value: string, encoded: boolean) {
     super();
-    this.value = value;
+    this.value = encoded ? value : PDFString.encode(value);
   }
 
   clone(): PDFString {
-    return PDFString.of(this.value);
+    return new PDFString(this.value, true);
   }
 
   toString(): string {
-    return `(${this.value})`;
+    return this.value;
   }
 
   sizeInBytes(): number {
-    return this.value.length + 2;
+    return this.value.length;
   }
 
   copyBytesInto(buffer: Uint8Array, offset: number): number {
-    buffer[offset++] = CharCodes.LeftParen;
-    offset += copyStringIntoBuffer(this.value, buffer, offset);
-    buffer[offset++] = CharCodes.RightParen;
-    return this.value.length + 2;
+    return copyStringIntoBuffer(this.value, buffer, offset);
+  }
+
+  private static encode(s: string): string {
+    for (var i = 0; i < s.length; i++) {
+      if (s.charCodeAt(i) > 127) {
+        return PDFString.hexEncode(s);
+      }
+    }
+    return `(${s})`;
+  }
+
+  private static hexEncode(s: string): string {
+    var text = "<FEFF";
+    utfx.UTF8toUTF16(utfx.stringSource(s), (cp: number) => {
+        text += toHexStringOfMinLength(cp, 4);
+    });
+    return text + ">";
   }
 }
 

--- a/src/types/utfx.d.ts
+++ b/src/types/utfx.d.ts
@@ -1,0 +1,1 @@
+declare module 'utfx';

--- a/tests/core/objects/PDFString.spec.ts
+++ b/tests/core/objects/PDFString.spec.ts
@@ -27,6 +27,10 @@ describe(`PDFString`, () => {
     it(`does not escape nested parenthesis`, () => {
       expect(String(PDFString.of('(Foo((Bar))Qux)'))).toBe('((Foo((Bar))Qux))');
     });
+
+    it(`encodes non-Latin text`, () => {
+      expect(String(PDFString.of('кириллица'))).toBe('<FEFF043A043804400438043B043B043804460430>');
+    });
   });
 
   it(`can provide its size in bytes`, () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3850,6 +3850,11 @@ use@^3.1.0:
   resolved "https://registry.yarnpkg.com/use/-/use-3.1.1.tgz#d50c8cac79a19fbc20f2911f56eb973f4e10070f"
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
+utfx@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/utfx/-/utfx-1.0.1.tgz#d52b2fd632a99eca8d9d4a39eece014a6a2b0048"
+  integrity sha1-1Ssv1jKpnsqNnUo57s4BSmorAEg=
+
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"


### PR DESCRIPTION
ASCII representation for PDFString cannot handle code points above 127 (7-bit ASCII). Such strings have to be encoded as Unicode (UTF16+BOM). This implementation opts to represent them as hex strings for ease of encoding.