### PR TITLE
Draw wrapped text

### DIFF
--- a/src/api/PDFDocument.ts
+++ b/src/api/PDFDocument.ts
@@ -165,6 +165,9 @@ export default class PDFDocument {
   private readonly fonts: PDFFont[];
   private readonly images: PDFImage[];
 
+  /** The default word breaks used in PDFPage.drawText */
+  public defaultWordBreak: string[] = [" ", "-"]
+
   private constructor(context: PDFContext, ignoreEncryption: boolean) {
     assertIs(context, 'context', [[PDFContext, 'PDFContext']]);
     assertIs(ignoreEncryption, 'ignoreEncryption', ['boolean']);

--- a/src/api/PDFDocument.ts
+++ b/src/api/PDFDocument.ts
@@ -158,15 +158,15 @@ export default class PDFDocument {
   /** Whether or not this document is encrypted. */
   readonly isEncrypted: boolean;
 
+  /** The default word breaks used in PDFPage.drawText */
+  defaultWordBreak: string[] = [' ', '-'];
+
   private fontkit?: Fontkit;
   private pageCount: number | undefined;
   private readonly pageCache: Cache<PDFPage[]>;
   private readonly pageMap: Map<PDFPageLeaf, PDFPage>;
   private readonly fonts: PDFFont[];
   private readonly images: PDFImage[];
-
-  /** The default word breaks used in PDFPage.drawText */
-  public defaultWordBreak: string[] = [" ", "-"]
 
   private constructor(context: PDFContext, ignoreEncryption: boolean) {
     assertIs(context, 'context', [[PDFContext, 'PDFContext']]);

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -598,6 +598,10 @@ export default class PDFPage {
         wordBreak = [wordBreak];
       }
 
+      if (wordBreak.length === 0) {
+        throw new TypeError('The array `options.wordBreak` cannot be empty.');
+      }
+
       for (let i = 0; i < wordBreak.length; i++) {
         const el = wordBreak[i];
         if (typeof(el) !== "string") {

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -604,7 +604,7 @@ export default class PDFPage {
 
       for (let i = 0; i < wordBreak.length; i++) {
         const el = wordBreak[i];
-        if (typeof(el) !== "string") {
+        if (typeof(el) !== 'string') {
           assertIs(options.maxWidth, `options.wordBreak[${i}]`, ['string']);
         } else if (el.length === 0) {
           throw new TypeError(`The string of \`options.wordBreak[${i}]\` must be at least 1 character long.`);
@@ -615,16 +615,18 @@ export default class PDFPage {
 
       const maxWidth = options.maxWidth || this.getWidth();
       const fontSize = options.size || this.fontSize;
-      const words: {content: string, width: number, forceBreak: boolean}[] = [];
-      const regex = new RegExp(wordBreak.map(escapeRegExp).join('|') + '|\\r\\n|\\r|\\n', 'gm')
+      const words: Array<{content: string, width: number, forceBreak: boolean}> = [];
+      const regex = new RegExp(wordBreak.map(escapeRegExp).join('|') + '|\\r\\n|\\r|\\n', 'gm');
       let shouldForceBreak = false;
       let index = 0;
       let match;
 
-      while ((match = regex.exec(text)) !== null) {
+      match = regex.exec(text);
+
+      while (match !== null) {
         let seperator = match[0];
-        let seperatorLength = seperator.length;
-        let forceBreak = shouldForceBreak;
+        const seperatorLength = seperator.length;
+        const forceBreak = shouldForceBreak;
 
         if (seperator === '\n' || seperator === '\r' || seperator === '\r\n') {
           seperator = '';
@@ -633,25 +635,26 @@ export default class PDFPage {
           shouldForceBreak = false;
         }
 
-        let content = text.substr(index, match.index - index) + seperator;
+        const content = text.substr(index, match.index - index) + seperator;
 
         words.push({
-          content: content,
+          content,
           width: font.widthOfTextAtSize(content, fontSize),
-          forceBreak: forceBreak
+          forceBreak
         });
 
         index = match.index + seperatorLength;
+        match = regex.exec(text);
       }
 
       if (index < text.length) {
-        let content = text.substr(index, text.length);
+        const content = text.substr(index, text.length);
 
         words.push({
-          content: content,
+          content,
           width: font.widthOfTextAtSize(content, fontSize),
           forceBreak: false
-        })
+        });
       }
 
       const wrappedLines = [];
@@ -659,14 +662,14 @@ export default class PDFPage {
       let line = '';
 
       for (let i = 0; i < words.length; i++) {
-        let word = words[i];
+        const word = words[i];
         let newLineWidth = lineWidth + word.width;
 
         if (word.forceBreak || lineWidth > 0 && newLineWidth >= maxWidth) {
           wrappedLines.push(line);
           lineWidth = 0;
           line = '';
-          newLineWidth = word.width
+          newLineWidth = word.width;
         }
 
         line += word.content;

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -598,10 +598,19 @@ export default class PDFPage {
         wordBreak = [wordBreak];
       }
 
+      for (let i = 0; i < wordBreak.length; i++) {
+        const el = wordBreak[i];
+        if (typeof(el) !== "string") {
+          assertIs(options.maxWidth, `options.wordBreak.${i}`, ['string']);
+        } else if (el.length === 0) {
+          throw new TypeError(`The string of options.wordBreak.${i} must be at least 1 character long.`);
+        }
+      }
+
       const maxWidth = options.maxWidth || this.getWidth();
       const fontSize = options.size || this.fontSize;
       const words: {content: string, width: number}[] = [];
-      const regex = new RegExp(wordBreak.map(escapeRegExp).join('|'), 'gm')
+      const regex = new RegExp(wordBreak.map(escapeRegExp).join('|'), 'gs')
       let index = 0;
       let match;
 

--- a/src/api/PDFPageOptions.ts
+++ b/src/api/PDFPageOptions.ts
@@ -12,10 +12,8 @@ export interface PDFPageDrawTextOptions {
   x?: number;
   y?: number;
   lineHeight?: number;
-}
-
-export interface PDFPageDrawWrappedTextOptions extends PDFPageDrawTextOptions {
   maxWidth?: number;
+  wordBreak?: string[];
 }
 
 export interface PDFPageDrawImageOptions {

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -33,3 +33,5 @@ export const copyStringIntoBuffer = (
 
 export const addRandomSuffix = (prefix: string, suffixLength = 4) =>
   `${prefix}-${Math.floor(Math.random() * 10 ** suffixLength)}`;
+
+export const escapeRegExp = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -34,4 +34,4 @@ export const copyStringIntoBuffer = (
 export const addRandomSuffix = (prefix: string, suffixLength = 4) =>
   `${prefix}-${Math.floor(Math.random() * 10 ** suffixLength)}`;
 
-export const escapeRegExp = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+export const escapeRegExp = (str: string) => str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');


### PR DESCRIPTION
This PR extends #173 created by @multiplegeorges.

The following has been changed:

1. Moved the API `drawWrappedText` to `drawText` with `maxWidth` as option (suggested by @Hopding).
2. Improved efficiency of the implementation (suggested by @Hopding).
3. Added the option `wordBreak` (suggested by @vicary).
4. Allowing multiple word breaking characters (e.g. `' '` and `'-'`).

# Examples
## Simple example
Simple example that shows multiple breaking characters and a new line in the text.

```js
const pdfDoc = await PDFLib.PDFDocument.create();

const page = pdfDoc.addPage([350, 400]);
page.moveTo(110, 220);
page.drawRectangle({
    width: 100,
    height: 10,
})

page.moveTo(110, 200);
page.drawText('Foo bar baz\nFoo-bar-baz', {
    maxWidth: 100,
    wordBreak: [' ', '-'] // Note: this is also the default value.
});
```

**Result**
![image](https://user-images.githubusercontent.com/2109929/65164588-81f9c200-da3d-11e9-8de9-b7361a36b80e.png)

## Default word breaking characters
The default word breaking characters (or words) can be set in PDFDocument.
Noteworthy that this isn't static and should be set when the document is created, otherwise you would get a race-condition if multiple functions would change the `defaultWordBreak`.

```js
const pdfDoc = await PDFLib.PDFDocument.create();
pdfDoc.defaultWordBreak = ["%"];

const page = pdfDoc.addPage([350, 400]);
page.moveTo(110, 220);
page.drawRectangle({
    width: 100,
    height: 10,
})

page.moveTo(110, 200);
page.drawText('Foo%bar%baz', {
    maxWidth: 100
});
```

**Result**
![image](https://user-images.githubusercontent.com/2109929/65165022-40b5e200-da3e-11e9-8679-cafa79eec772.png)

# Security
The following word breaking characters are invalid: `'\n'`, `'\r'`:

1. `widthOfTextAtSize` doesn't support new-lines.
2. ~~An empty string would cause a RegEx DoS attack.~~
   Changed in the last commit: https://github.com/Hopding/pdf-lib/pull/193#issuecomment-533473638
3. At least 1 breaking character should be given when `maxWidth` is set.

# License
The function `escapeRegExp` is from https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions#Escaping licensed under [public domain (CC0)](https://developer.mozilla.org/en-US/docs/MDN/About#Copyrights_and_licenses).