### PR TITLE
Update PDFAcroFields.Kids to return dereferenced fields or annotation widgets

### DIFF
--- a/src/core/structures/acroform/PDFAcroField.ts
+++ b/src/core/structures/acroform/PDFAcroField.ts
@@ -40,7 +40,9 @@ class PDFAcroField {
   }
 
   Kids(): PDFAcroField[] | PDFDict[] | undefined {
-    return this.dict.lookupMaybe(PDFName.Kids, PDFArray)?.lookupElements(PDFDict);
+    return this.dict
+      .lookupMaybe(PDFName.Kids, PDFArray)
+      ?.lookupElements(PDFDict);
   }
 
   T(): PDFString | undefined {

--- a/src/core/structures/acroform/PDFAcroField.ts
+++ b/src/core/structures/acroform/PDFAcroField.ts
@@ -39,8 +39,8 @@ class PDFAcroField {
     return this.dict.lookupMaybe(PDFName.of('Parent'), PDFDict);
   }
 
-  Kids(): PDFArray | undefined {
-    return this.dict.lookupMaybe(PDFName.Kids, PDFArray);
+  Kids(): PDFAcroField[] | PDFDict[] | undefined {
+    return this.dict.lookupMaybe(PDFName.Kids, PDFArray)?.lookupElements(PDFDict);
   }
 
   T(): PDFString | undefined {

--- a/src/core/structures/acroform/PDFNonTerminalField.ts
+++ b/src/core/structures/acroform/PDFNonTerminalField.ts
@@ -13,7 +13,9 @@ class PDFNonTerminalField extends PDFAcroField {
   }
 
   Kids(): PDFAcroField[] {
-    const kidsDicts = this.dict.lookup(PDFName.Kids, PDFArray).lookupElements(PDFDict);
+    const kidsDicts = this.dict
+      .lookup(PDFName.Kids, PDFArray)
+      .lookupElements(PDFDict);
     const kidsAcroFields = new Array<PDFAcroField>(kidsDicts.length);
     for (let idx = 0, len = kidsDicts.length; idx < len; idx++) {
       kidsAcroFields[idx] = PDFAcroField.fromDict(kidsDicts[idx]);

--- a/src/core/structures/acroform/PDFNonTerminalField.ts
+++ b/src/core/structures/acroform/PDFNonTerminalField.ts
@@ -12,8 +12,13 @@ class PDFNonTerminalField extends PDFAcroField {
     super(dict);
   }
 
-  Kids(): PDFArray {
-    return this.dict.lookup(PDFName.Kids, PDFArray);
+  Kids(): PDFAcroField[] {
+    const kidsDicts = this.dict.lookup(PDFName.Kids, PDFArray).lookupElements(PDFDict);
+    const kidsAcroFields = new Array<PDFAcroField>(kidsDicts.length);
+    for (let idx = 0, len = kidsDicts.length; idx < len; idx++) {
+      kidsAcroFields[idx] = PDFAcroField.fromDict(kidsDicts[idx]);
+    }
+    return kidsAcroFields;
   }
 }
 

--- a/tests/core/structures/acroform/PDFAcroField.spec.ts
+++ b/tests/core/structures/acroform/PDFAcroField.spec.ts
@@ -65,7 +65,7 @@ describe('PDFAcroField', () => {
       dict.set(PDFName.Kids, kids);
       const acroFormFieldDict = PDFDict.fromMapWithContext(dict, context);
       const field = PDFAcroField.fromDict(acroFormFieldDict);
-      expect(field.Kids()).toBe(kids);
+      expect(field.Kids()).toEqual([]);
     });
 
     it('when it is undefined', () => {

--- a/tests/core/structures/acroform/PDFNonTerminalField.spec.ts
+++ b/tests/core/structures/acroform/PDFNonTerminalField.spec.ts
@@ -1,5 +1,6 @@
 import {
   DictMap,
+  PDFAcroField,
   PDFArray,
   PDFContext,
   PDFDict,
@@ -15,11 +16,20 @@ describe('PDFNonTerminalField', () => {
     context = PDFContext.create();
   });
 
-  it('returns a valid kids array', () => {
+  it('returns a valid kids array of PDFAcroFields', () => {
     const kidsArray = PDFArray.withContext(context);
+    const childDict = PDFDict.fromMapWithContext(
+      new Map([
+        [PDFName.FT, PDFName.Btn]
+      ]),
+      context
+    );
+    const childDictRef = context.register(childDict);
+    const childAcroField = PDFAcroField.fromDict(childDict);
+    kidsArray.push(childDictRef);
     dict = new Map([[PDFName.Kids, kidsArray]]);
     const acroFormFieldDict = PDFDict.fromMapWithContext(dict, context);
     const field = PDFNonTerminalField.fromDict(acroFormFieldDict);
-    expect(field.Kids()).toBe(kidsArray);
+    expect(field.Kids()).toEqual([childAcroField]);
   });
 });

--- a/tests/core/structures/acroform/PDFNonTerminalField.spec.ts
+++ b/tests/core/structures/acroform/PDFNonTerminalField.spec.ts
@@ -19,10 +19,8 @@ describe('PDFNonTerminalField', () => {
   it('returns a valid kids array of PDFAcroFields', () => {
     const kidsArray = PDFArray.withContext(context);
     const childDict = PDFDict.fromMapWithContext(
-      new Map([
-        [PDFName.FT, PDFName.Btn]
-      ]),
-      context
+      new Map([[PDFName.FT, PDFName.Btn]]),
+      context,
     );
     const childDictRef = context.register(childDict);
     const childAcroField = PDFAcroField.fromDict(childDict);


### PR DESCRIPTION
Fixes #285 