### PR TITLE
Opacity - semi transparent objects

### DIFF
--- a/apps/deno/tests/test12.ts
+++ b/apps/deno/tests/test12.ts
@@ -93,6 +93,22 @@ export default async (_assets: Assets) => {
       borderWidth: 2,
     },
   );
+  page2.drawCircle({
+    x: inchToPt(3),
+    y: inchToPt(5),
+    color: rgb(0, 1, 1),
+    opacity: 0.1,
+    borderWidth: 3,
+    borderColor: rgb(1, 0, 1),
+    borderOpacity: 0.2
+  });
+  page2.drawText("Semi-Transparent Text", {
+    color: rgb(0, 1, 1),
+    opacity: 0.5,
+    x: inchToPt(1),
+    y: inchToPt(2.5),
+    size: 50
+  });
 
   const pdfBytes = await pdfDoc.save();
   return pdfBytes;

--- a/apps/deno/tests/test2.ts
+++ b/apps/deno/tests/test2.ts
@@ -74,6 +74,7 @@ export default async (assets: Assets) => {
       width: textWidth + 10,
       height: boxHeight,
       color: solarizedWhite,
+      opacity: 0.85,
       borderColor: solarizedGray,
       borderWidth: 3,
     });
@@ -89,6 +90,7 @@ export default async (assets: Assets) => {
       width: embeddedPageFigure.width / 2 + embeddedPageFigure.padding * 2,
       height: embeddedPageFigure.height / 2 + embeddedPageFigure.padding * 2,
       color: solarizedWhite,
+      opacity: 0.6,
       borderColor: solarizedGray,
       borderWidth: 2,
     });

--- a/apps/deno/tests/test4.ts
+++ b/apps/deno/tests/test4.ts
@@ -58,6 +58,7 @@ export default async (assets: Assets) => {
       ...minionsLaughingDims,
       x: centerX - minionsLaughingDims.width / 2,
       y: centerY - minionsLaughingDims.height / 2,
+      opacity: 0.9
     });
   };
 

--- a/apps/node/tests/test12.ts
+++ b/apps/node/tests/test12.ts
@@ -1,5 +1,5 @@
 import { Assets } from '..';
-import { PageSizes, PDFDocument, rgb } from '../../..';
+import { PageSizes, PDFDocument, rgb, degrees } from '../../..';
 
 const inchToPt = (inches: number) => Math.round(inches * 72);
 
@@ -93,6 +93,22 @@ export default async (_assets: Assets) => {
       borderWidth: 2,
     },
   );
+  page2.drawCircle({
+    x: inchToPt(3),
+    y: inchToPt(5),
+    color: rgb(0, 1, 1),
+    opacity: 0.1,
+    borderWidth: 3,
+    borderColor: rgb(1, 0, 1),
+    borderOpacity: 0.2
+  });
+  page2.drawText("Semi-Transparent Text", {
+    color: rgb(0, 1, 1),
+    opacity: 0.5,
+    x: inchToPt(1),
+    y: inchToPt(2.5),
+    size: 50
+  });
 
   const pdfBytes = await pdfDoc.save();
   return pdfBytes;

--- a/apps/node/tests/test2.ts
+++ b/apps/node/tests/test2.ts
@@ -69,6 +69,7 @@ export default async (assets: Assets) => {
       width: textWidth + 10,
       height: boxHeight,
       color: solarizedWhite,
+      opacity: 0.85,
       borderColor: solarizedGray,
       borderWidth: 3,
     });
@@ -84,6 +85,7 @@ export default async (assets: Assets) => {
       width: embeddedPageFigure.width / 2 + embeddedPageFigure.padding * 2,
       height: embeddedPageFigure.height / 2 + embeddedPageFigure.padding * 2,
       color: solarizedWhite,
+      opacity: 0.6,
       borderColor: solarizedGray,
       borderWidth: 2,
     });

--- a/apps/node/tests/test4.ts
+++ b/apps/node/tests/test4.ts
@@ -58,6 +58,7 @@ export default async (assets: Assets) => {
       ...minionsLaughingDims,
       x: centerX - minionsLaughingDims.width / 2,
       y: centerY - minionsLaughingDims.height / 2,
+      opacity: 0.9
     });
   };
 

--- a/apps/rn/src/tests/test12.js
+++ b/apps/rn/src/tests/test12.js
@@ -94,6 +94,22 @@ export default async () => {
       borderWidth: 2,
     },
   );
+  page2.drawCircle({
+    x: inchToPt(3),
+    y: inchToPt(5),
+    color: rgb(0, 1, 1),
+    opacity: 0.1,
+    borderWidth: 3,
+    borderColor: rgb(1, 0, 1),
+    borderOpacity: 0.2
+  });
+  page2.drawText("Semi-Transparent Text", {
+    color: rgb(0, 1, 1),
+    opacity: 0.5,
+    x: inchToPt(1),
+    y: inchToPt(2.5),
+    size: 50
+  });
 
   const base64Pdf = await pdfDoc.saveAsBase64({ dataUri: true });
 

--- a/apps/rn/src/tests/test2.js
+++ b/apps/rn/src/tests/test2.js
@@ -75,6 +75,7 @@ export default async () => {
       width: textWidth + 10,
       height: boxHeight,
       color: solarizedWhite,
+      opacity: 0.85,
       borderColor: solarizedGray,
       borderWidth: 3,
     });
@@ -90,6 +91,7 @@ export default async () => {
       width: embeddedPageFigure.width / 2 + embeddedPageFigure.padding * 2,
       height: embeddedPageFigure.height / 2 + embeddedPageFigure.padding * 2,
       color: solarizedWhite,
+      opacity: 0.6,
       borderColor: solarizedGray,
       borderWidth: 2,
     });

--- a/apps/rn/src/tests/test4.js
+++ b/apps/rn/src/tests/test4.js
@@ -48,6 +48,7 @@ export default async () => {
       ...minionsLaughingDims,
       x: centerX - minionsLaughingDims.width / 2,
       y: centerY - minionsLaughingDims.height / 2,
+      opacity: 0.9
     });
   };
 

--- a/apps/web/test12.html
+++ b/apps/web/test12.html
@@ -141,6 +141,22 @@
           borderWidth: 2,
         },
       );
+      page2.drawCircle({
+        x: inchToPt(3),
+        y: inchToPt(5),
+        color: rgb(0, 1, 1),
+        opacity: 0.1,
+        borderWidth: 3,
+        borderColor: rgb(1, 0, 1),
+        borderOpacity: 0.2
+      });
+      page2.drawText("Semi-Transparent Text", {
+        color: rgb(0, 1, 1),
+        opacity: 0.5,
+        x: inchToPt(1),
+        y: inchToPt(2.5),
+        size: 50
+      });
 
       const pdfBytes = await pdfDoc.save();
 

--- a/apps/web/test2.html
+++ b/apps/web/test2.html
@@ -124,6 +124,7 @@
           width: textWidth + 10,
           height: boxHeight,
           color: solarizedWhite,
+          opacity: 0.85,
           borderColor: solarizedGray,
           borderWidth: 3,
         });
@@ -140,6 +141,7 @@
           height:
             embeddedPageFigure.height / 2 + embeddedPageFigure.padding * 2,
           color: solarizedWhite,
+          opacity: 0.6,
           borderColor: solarizedGray,
           borderWidth: 2,
         });

--- a/apps/web/test4.html
+++ b/apps/web/test4.html
@@ -95,6 +95,7 @@
           ...minionsLaughingDims,
           x: centerX - minionsLaughingDims.width / 2,
           y: centerY - minionsLaughingDims.height / 2,
+          opacity: 0.9
         });
       };
 

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -1020,6 +1020,8 @@ export default class PDFPage {
     assertOrUndefined(options.rotate, 'options.rotate', [[Object, 'Rotation']]);
     assertOrUndefined(options.xSkew, 'options.xSkew', [[Object, 'Rotation']]);
     assertOrUndefined(options.ySkew, 'options.ySkew', [[Object, 'Rotation']]);
+    assertOrUndefined(options.opacity, 'options.opacity', ['number']);
+    assertOrUndefined(options.borderOpacity, 'options.borderOpacity', ['number']);
 
     const xObjectKey = addRandomSuffix('EmbeddedPdfPage', 10);
     this.node.setXObject(PDFName.of(xObjectKey), embeddedPage.ref);
@@ -1039,14 +1041,17 @@ export default class PDFPage {
     );
 
     this.addToContentStream(drawPage(xObjectKey, {
-      x: options.x ?? this.x,
-      y: options.y ?? this.y,
-      xScale,
-      yScale,
-      rotate: options.rotate ?? degrees(0),
-      xSkew: options.xSkew ?? degrees(0),
-      ySkew: options.ySkew ?? degrees(0),
-    }));
+        x: options.x ?? this.x,
+        y: options.y ?? this.y,
+        xScale,
+        yScale,
+        rotate: options.rotate ?? degrees(0),
+        xSkew: options.xSkew ?? degrees(0),
+        ySkew: options.ySkew ?? degrees(0),
+      }),
+      options.opacity,
+      options.borderOpacity
+    );
   }
 
   /**

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -1144,9 +1144,7 @@ export default class PDFPage {
         y: options.y ?? this.y,
         scale: options.scale,
         color: options.color ?? undefined,
-        opacity: opacity,
         borderColor: options.borderColor ?? undefined,
-        borderOpacity: borderOpacity,
         borderWidth: options.borderWidth ?? 0,
       }),
     );

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -1095,9 +1095,11 @@ export default class PDFPage {
     assertOrUndefined(options.scale, 'options.scale', ['number']);
     assertOrUndefined(options.borderWidth, 'options.borderWidth', ['number']);
     assertOrUndefined(options.color, 'options.color', [[Object, 'Color']]);
+    assertOrUndefined(options.opacity, 'options.opacity', ['number']);
     assertOrUndefined(options.borderColor, 'options.borderColor', [
       [Object, 'Color'],
     ]);
+    assertOrUndefined(options.opacity, 'options.borderOpacity', ['number']);
 
     const contentStream = this.getContentStream();
     if (!('color' in options) && !('borderColor' in options)) {
@@ -1109,7 +1111,9 @@ export default class PDFPage {
         y: options.y ?? this.y,
         scale: options.scale,
         color: options.color ?? undefined,
+        opacity: options.opacity ?? 1,
         borderColor: options.borderColor ?? undefined,
+        borderOpacity: options.opacity ?? 1,
         borderWidth: options.borderWidth ?? 0,
       }),
     );

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -49,6 +49,7 @@ import {
   breakTextIntoLines,
   cleanText,
   rectanglesAreEqual,
+  assertRange,
 } from 'src/utils';
 
 /**
@@ -1110,22 +1111,25 @@ export default class PDFPage {
 
     const opacity = options.opacity ?? 1;
     const borderOpacity = options.borderOpacity ?? 1;
+    assertRange(opacity, "opacity", 0, 1);
+    assertRange(borderOpacity, "borderOpacity", 0, 1);
 
     const extGStateKey = addRandomSuffix('GS', 10);
     const {Resources} = this.node.normalizedEntries();
     const pdfNameExtGState = PDFName.of('ExtGState');
-    const gsObject = this.doc.context.obj({
-      [extGStateKey]: {
-        Type: 'ExtGState',
-        ca: opacity,
-        CA: borderOpacity
-      }
-    });
+    const gsObject = {
+      Type: 'ExtGState',
+      ca: opacity,
+      CA: borderOpacity
+    };
+
     let extGState = Resources.get(pdfNameExtGState) as PDFDict;
     if (extGState) {
-      extGState.set(PDFName.of(extGStateKey), gsObject);
+      extGState.set(PDFName.of(extGStateKey), this.doc.context.obj(gsObject));
     } else {
-      extGState = gsObject;
+      extGState = this.doc.context.obj({
+        [extGStateKey]: gsObject
+      });
       Resources.set(PDFName.of('ExtGState'), extGState);
     }
 

--- a/src/api/PDFPageOptions.ts
+++ b/src/api/PDFPageOptions.ts
@@ -97,5 +97,7 @@ export interface PDFPageDrawSVGOptions {
   scale?: number;
   borderWidth?: number;
   color?: Color;
+  opacity?: number;
   borderColor?: Color;
+  borderOpacity?: number;
 }

--- a/src/api/PDFPageOptions.ts
+++ b/src/api/PDFPageOptions.ts
@@ -5,6 +5,7 @@ import { LineCapStyle } from 'src/api/operators';
 
 export interface PDFPageDrawTextOptions {
   color?: Color;
+  opacity?: number;
   font?: PDFFont;
   size?: number;
   rotate?: Rotation;
@@ -50,7 +51,9 @@ export interface PDFPageDrawRectangleOptions {
   ySkew?: Rotation;
   borderWidth?: number;
   color?: Color;
+  opacity?: number;
   borderColor?: Color;
+  borderOpacity?: number;
 }
 
 export interface PDFPageDrawLineOptions {
@@ -59,6 +62,7 @@ export interface PDFPageDrawLineOptions {
   thickness?: number;
   color?: Color;
   lineCap?: LineCapStyle;
+  opacity?: number;
 }
 
 export interface PDFPageDrawSquareOptions {
@@ -70,7 +74,9 @@ export interface PDFPageDrawSquareOptions {
   ySkew?: Rotation;
   borderWidth?: number;
   color?: Color;
+  opacity?: number;
   borderColor?: Color;
+  borderOpacity?: number;
 }
 
 export interface PDFPageDrawEllipseOptions {
@@ -79,7 +85,9 @@ export interface PDFPageDrawEllipseOptions {
   xScale?: number;
   yScale?: number;
   color?: Color;
+  opacity?: number;
   borderColor?: Color;
+  borderOpacity?: number;
   borderWidth?: number;
 }
 
@@ -88,7 +96,9 @@ export interface PDFPageDrawCircleOptions {
   y?: number;
   size?: number;
   color?: Color;
+  opacity?: number;
   borderColor?: Color;
+  borderOpacity?: number;
   borderWidth?: number;
 }
 

--- a/src/api/PDFPageOptions.ts
+++ b/src/api/PDFPageOptions.ts
@@ -25,6 +25,7 @@ export interface PDFPageDrawImageOptions {
   rotate?: Rotation;
   xSkew?: Rotation;
   ySkew?: Rotation;
+  opacity?: number;
 }
 
 export interface PDFPageDrawPageOptions {

--- a/src/api/PDFPageOptions.ts
+++ b/src/api/PDFPageOptions.ts
@@ -39,6 +39,8 @@ export interface PDFPageDrawPageOptions {
   rotate?: Rotation;
   xSkew?: Rotation;
   ySkew?: Rotation;
+  opacity?: number;
+  borderOpacity?: number;
 }
 
 export interface PDFPageDrawRectangleOptions {

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -255,7 +255,9 @@ export const drawSvgPath = (
     y: number | PDFNumber;
     scale: number | PDFNumber | undefined;
     color: Color | undefined;
+    opacity: number | PDFNumber | undefined;
     borderColor: Color | undefined;
+    borderOpacity: number | PDFNumber | undefined;
     borderWidth: number | PDFNumber;
   },
 ) =>

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -255,9 +255,7 @@ export const drawSvgPath = (
     y: number | PDFNumber;
     scale: number | PDFNumber | undefined;
     color: Color | undefined;
-    opacity: number | PDFNumber | undefined;
     borderColor: Color | undefined;
-    borderOpacity: number | PDFNumber | undefined;
     borderWidth: number | PDFNumber;
   },
 ) =>

--- a/src/api/operators.ts
+++ b/src/api/operators.ts
@@ -104,6 +104,9 @@ export enum LineJoinStyle {
 export const setLineJoin = (style: LineJoinStyle) =>
   PDFOperator.of(Ops.SetLineJoinStyle, [asPDFNumber(style)]);
 
+export const setGraphicsState = (state: string | PDFName) =>
+  PDFOperator.of(Ops.SetGraphicsStateParams, [asPDFName(state)]);
+
 export const pushGraphicsState = () => PDFOperator.of(Ops.PushGraphicsState);
 
 export const popGraphicsState = () => PDFOperator.of(Ops.PopGraphicsState);


### PR DESCRIPTION
Hey @Hopding ,

So I thought I'd submit a PR for #210 , as you suggested yesterday.

Some notes:
- I've tested it, it works for my case, but there might be some cases I've missed.
- Maybe I shouldn't push a new graphic state if both `opacity` and `borderOpacity` is 1 (or left untouched, as the default value is 1 for both of them)? I'm not sure about best practices when it comes to PDF.
- Since it's only for `svgPath`s so far, I'd still need to add these things to `drawText` (as in the original issue), and a lot of other stuff (`drawLine`, `drawCircle`, `drawSquare`, `drawImage`, etc). In that case, I should try to avoid most of the code duplication related to this feature with private methods for example. Please let me know if you have any preferences, thoughts, warnings about this!

Have a great week!