### PR TITLE
Added highlevel ability to provide lineCap style

### DIFF
--- a/apps/deno/tests/test1.ts
+++ b/apps/deno/tests/test1.ts
@@ -155,6 +155,20 @@ export default async (assets: Assets) => {
   });
   page1.pushOperators(popGraphicsState());
 
+  page1.drawLine({
+    start: {
+      x: size / 4,
+      y: size / 4
+    },
+    end: {
+      x: size / 4 + 100,
+      y: size / 4 + 100
+    },
+    color: rgb(0, 1, 0),
+    thickness: 3,
+    dashArray: [12, 12]
+  });
+
   // Lower-right quadrant
   page1.moveTo(size / 2, 0);
   page1.drawSquare({ size: size / 2, color: grayscale(0.8) });

--- a/apps/deno/tests/test1.ts
+++ b/apps/deno/tests/test1.ts
@@ -18,7 +18,6 @@ import {
   popGraphicsState,
   pushGraphicsState,
   rgb,
-  setDashPattern,
   setLineCap,
   setLineJoin,
   StandardFonts,
@@ -143,10 +142,7 @@ export default async (assets: Assets) => {
   // Lower-left quadrant
   page1.moveTo(0, 0);
   page1.drawSquare({ size: size / 2, color: cmyk(1, 0, 0, 0) });
-  page1.pushOperators(
-    pushGraphicsState(),
-    setLineCap(LineCapStyle.Round),
-  );
+
   page1.drawCircle({
     x: size / 4,
     y: size / 4,
@@ -155,8 +151,8 @@ export default async (assets: Assets) => {
     dashArray: [25],
     dashPhase: 25,
     borderColor: cmyk(0, 1, 0, 0),
+    lineCap: LineCapStyle.Round,
   });
-  page1.pushOperators(popGraphicsState());
 
   page1.drawLine({
     start: {
@@ -170,6 +166,7 @@ export default async (assets: Assets) => {
     color: rgb(0, 1, 0),
     thickness: 3,
     dashArray: [12, 6],
+    lineCap: LineCapStyle.Round,
   });
 
   // Lower-right quadrant

--- a/apps/deno/tests/test1.ts
+++ b/apps/deno/tests/test1.ts
@@ -18,7 +18,6 @@ import {
   popGraphicsState,
   pushGraphicsState,
   rgb,
-  setLineCap,
   setLineJoin,
   StandardFonts,
 } from '../../../dist/pdf-lib.esm.js';
@@ -152,7 +151,7 @@ export default async (assets: Assets) => {
     borderDashArray: [25],
     borderDashPhase: 25,
     borderColor: cmyk(0, 1, 0, 0),
-    lineCap: LineCapStyle.Round,
+    borderLineCap: LineCapStyle.Round,
   });
 
   page1.drawLine({

--- a/apps/deno/tests/test1.ts
+++ b/apps/deno/tests/test1.ts
@@ -98,6 +98,8 @@ export default async (assets: Assets) => {
       xSkew: degrees(0),
       ySkew: degrees(0),
       color: undefined,
+      dashArray: [],
+      dashPhase: 0,
     }),
     popGraphicsState(),
   );
@@ -143,7 +145,6 @@ export default async (assets: Assets) => {
   page1.drawSquare({ size: size / 2, color: cmyk(1, 0, 0, 0) });
   page1.pushOperators(
     pushGraphicsState(),
-    setDashPattern([25], 25),
     setLineCap(LineCapStyle.Round),
   );
   page1.drawCircle({
@@ -151,6 +152,8 @@ export default async (assets: Assets) => {
     y: size / 4,
     size: 150,
     borderWidth: 10,
+    dashArray: [25],
+    dashPhase: 25,
     borderColor: cmyk(0, 1, 0, 0),
   });
   page1.pushOperators(popGraphicsState());
@@ -166,7 +169,7 @@ export default async (assets: Assets) => {
     },
     color: rgb(0, 1, 0),
     thickness: 3,
-    dashArray: [12, 12]
+    dashArray: [12, 6],
   });
 
   // Lower-right quadrant

--- a/apps/deno/tests/test12.ts
+++ b/apps/deno/tests/test12.ts
@@ -62,6 +62,7 @@ export default async (_assets: Assets) => {
     y: inchToPt(11),
     scale: 0.5,
     borderWidth: 2,
+    dashArray: [12, 6],
   });
   page2.drawSvgPath('M200,300 L400,50 L600,300 L800,550 L1000,300', {
     x: inchToPt(-1),

--- a/apps/deno/tests/test12.ts
+++ b/apps/deno/tests/test12.ts
@@ -1,5 +1,5 @@
 import { Assets } from '../index.ts';
-import { PageSizes, PDFDocument, rgb } from '../../../dist/pdf-lib.esm.js';
+import { PageSizes, PDFDocument, rgb, LineCapStyle } from '../../../dist/pdf-lib.esm.js';
 
 const inchToPt = (inches: number) => Math.round(inches * 72);
 
@@ -61,8 +61,9 @@ export default async (_assets: Assets) => {
     x: inchToPt(-1),
     y: inchToPt(11),
     scale: 0.5,
-    borderWidth: 2,
-    dashArray: [12, 6],
+    borderWidth: 4,
+    dashArray: [24, 12],
+    lineCap: LineCapStyle.Round,
   });
   page2.drawSvgPath('M200,300 L400,50 L600,300 L800,550 L1000,300', {
     x: inchToPt(-1),

--- a/apps/deno/tests/test12.ts
+++ b/apps/deno/tests/test12.ts
@@ -63,7 +63,7 @@ export default async (_assets: Assets) => {
     scale: 0.5,
     borderWidth: 4,
     borderDashArray: [24, 12],
-    lineCap: LineCapStyle.Round,
+    borderLineCap: LineCapStyle.Round,
   });
   page2.drawSvgPath('M200,300 L400,50 L600,300 L800,550 L1000,300', {
     x: inchToPt(-1),

--- a/apps/node/tests/test1.ts
+++ b/apps/node/tests/test1.ts
@@ -17,8 +17,6 @@ import {
   popGraphicsState,
   pushGraphicsState,
   rgb,
-  setDashPattern,
-  setLineCap,
   setLineJoin,
   StandardFonts,
   typedArrayFor,
@@ -143,10 +141,7 @@ export default async (assets: Assets) => {
   // Lower-left quadrant
   page1.moveTo(0, 0);
   page1.drawSquare({ size: size / 2, color: cmyk(1, 0, 0, 0) });
-  page1.pushOperators(
-    pushGraphicsState(),
-    setLineCap(LineCapStyle.Round),
-  );
+
   page1.drawCircle({
     x: size / 4,
     y: size / 4,
@@ -155,8 +150,8 @@ export default async (assets: Assets) => {
     dashArray: [25],
     dashPhase: 25,
     borderColor: cmyk(0, 1, 0, 0),
+    lineCap: LineCapStyle.Round,
   });
-  page1.pushOperators(popGraphicsState());
 
   page1.drawLine({
     start: {
@@ -170,6 +165,7 @@ export default async (assets: Assets) => {
     color: rgb(0, 1, 0),
     thickness: 3,
     dashArray: [12, 6],
+    lineCap: LineCapStyle.Round,
   });
 
   // Lower-right quadrant

--- a/apps/node/tests/test1.ts
+++ b/apps/node/tests/test1.ts
@@ -155,6 +155,20 @@ export default async (assets: Assets) => {
   });
   page1.pushOperators(popGraphicsState());
 
+  page1.drawLine({
+    start: {
+      x: size / 4,
+      y: size / 4
+    },
+    end: {
+      x: size / 4 + 100,
+      y: size / 4 + 100
+    },
+    color: rgb(0, 1, 0),
+    thickness: 3,
+    dashArray: [12, 12]
+  });
+
   // Lower-right quadrant
   page1.moveTo(size / 2, 0);
   page1.drawSquare({ size: size / 2, color: grayscale(0.8) });

--- a/apps/node/tests/test1.ts
+++ b/apps/node/tests/test1.ts
@@ -98,6 +98,8 @@ export default async (assets: Assets) => {
       xSkew: degrees(0),
       ySkew: degrees(0),
       color: undefined,
+      dashArray: [],
+      dashPhase: 0,
     }),
     popGraphicsState(),
   );
@@ -143,7 +145,6 @@ export default async (assets: Assets) => {
   page1.drawSquare({ size: size / 2, color: cmyk(1, 0, 0, 0) });
   page1.pushOperators(
     pushGraphicsState(),
-    setDashPattern([25], 25),
     setLineCap(LineCapStyle.Round),
   );
   page1.drawCircle({
@@ -151,6 +152,8 @@ export default async (assets: Assets) => {
     y: size / 4,
     size: 150,
     borderWidth: 10,
+    dashArray: [25],
+    dashPhase: 25,
     borderColor: cmyk(0, 1, 0, 0),
   });
   page1.pushOperators(popGraphicsState());
@@ -166,7 +169,7 @@ export default async (assets: Assets) => {
     },
     color: rgb(0, 1, 0),
     thickness: 3,
-    dashArray: [12, 12]
+    dashArray: [12, 6],
   });
 
   // Lower-right quadrant

--- a/apps/node/tests/test1.ts
+++ b/apps/node/tests/test1.ts
@@ -151,7 +151,7 @@ export default async (assets: Assets) => {
     borderDashArray: [25],
     borderDashPhase: 25,
     borderColor: cmyk(0, 1, 0, 0),
-    lineCap: LineCapStyle.Round,
+    borderLineCap: LineCapStyle.Round,
   });
 
   page1.drawLine({

--- a/apps/node/tests/test12.ts
+++ b/apps/node/tests/test12.ts
@@ -62,6 +62,7 @@ export default async (_assets: Assets) => {
     y: inchToPt(11),
     scale: 0.5,
     borderWidth: 2,
+    dashArray: [12, 6],
   });
   page2.drawSvgPath('M200,300 L400,50 L600,300 L800,550 L1000,300', {
     x: inchToPt(-1),

--- a/apps/node/tests/test12.ts
+++ b/apps/node/tests/test12.ts
@@ -63,7 +63,7 @@ export default async (_assets: Assets) => {
     scale: 0.5,
     borderWidth: 4,
     borderDashArray: [24, 12],
-    lineCap: LineCapStyle.Round,
+    borderLineCap: LineCapStyle.Round,
   });
   page2.drawSvgPath('M200,300 L400,50 L600,300 L800,550 L1000,300', {
     x: inchToPt(-1),

--- a/apps/node/tests/test12.ts
+++ b/apps/node/tests/test12.ts
@@ -1,5 +1,5 @@
 import { Assets } from '..';
-import { PageSizes, PDFDocument, rgb } from '../../..';
+import { PageSizes, PDFDocument, rgb, LineCapStyle } from '../../..';
 
 const inchToPt = (inches: number) => Math.round(inches * 72);
 
@@ -61,8 +61,9 @@ export default async (_assets: Assets) => {
     x: inchToPt(-1),
     y: inchToPt(11),
     scale: 0.5,
-    borderWidth: 2,
-    dashArray: [12, 6],
+    borderWidth: 4,
+    dashArray: [24, 12],
+    lineCap: LineCapStyle.Round,
   });
   page2.drawSvgPath('M200,300 L400,50 L600,300 L800,550 L1000,300', {
     x: inchToPt(-1),

--- a/apps/rn/src/tests/test1.js
+++ b/apps/rn/src/tests/test1.js
@@ -160,6 +160,20 @@ export default async () => {
   });
   page1.pushOperators(popGraphicsState());
 
+  page1.drawLine({
+    start: {
+      x: size / 4,
+      y: size / 4
+    },
+    end: {
+      x: size / 4 + 100,
+      y: size / 4 + 100
+    },
+    color: rgb(0, 1, 0),
+    thickness: 3,
+    dashArray: [12, 12]
+  });
+
   // Lower-right quadrant
   page1.moveTo(size / 2, 0);
   page1.drawSquare({ size: size / 2, color: grayscale(0.8) });

--- a/apps/rn/src/tests/test1.js
+++ b/apps/rn/src/tests/test1.js
@@ -103,6 +103,8 @@ export default async () => {
       xSkew: degrees(0),
       ySkew: degrees(0),
       color: undefined,
+      dashArray: [],
+      dashPhase: 0,
     }),
     popGraphicsState(),
   );
@@ -148,7 +150,6 @@ export default async () => {
   page1.drawSquare({ size: size / 2, color: cmyk(1, 0, 0, 0) });
   page1.pushOperators(
     pushGraphicsState(),
-    setDashPattern([25], 25),
     setLineCap(LineCapStyle.Round),
   );
   page1.drawCircle({
@@ -156,6 +157,8 @@ export default async () => {
     y: size / 4,
     size: 150,
     borderWidth: 10,
+    dashArray: [25],
+    dashPhase: 25,
     borderColor: cmyk(0, 1, 0, 0),
   });
   page1.pushOperators(popGraphicsState());
@@ -171,7 +174,7 @@ export default async () => {
     },
     color: rgb(0, 1, 0),
     thickness: 3,
-    dashArray: [12, 12]
+    dashArray: [12, 6],
   });
 
   // Lower-right quadrant

--- a/apps/rn/src/tests/test1.js
+++ b/apps/rn/src/tests/test1.js
@@ -17,8 +17,6 @@ import {
   popGraphicsState,
   pushGraphicsState,
   rgb,
-  setDashPattern,
-  setLineCap,
   setLineJoin,
   StandardFonts,
 } from 'pdf-lib';
@@ -148,10 +146,7 @@ export default async () => {
   // Lower-left quadrant
   page1.moveTo(0, 0);
   page1.drawSquare({ size: size / 2, color: cmyk(1, 0, 0, 0) });
-  page1.pushOperators(
-    pushGraphicsState(),
-    setLineCap(LineCapStyle.Round),
-  );
+
   page1.drawCircle({
     x: size / 4,
     y: size / 4,
@@ -160,8 +155,8 @@ export default async () => {
     dashArray: [25],
     dashPhase: 25,
     borderColor: cmyk(0, 1, 0, 0),
+    lineCap: LineCapStyle.Round,
   });
-  page1.pushOperators(popGraphicsState());
 
   page1.drawLine({
     start: {
@@ -175,6 +170,7 @@ export default async () => {
     color: rgb(0, 1, 0),
     thickness: 3,
     dashArray: [12, 6],
+    lineCap: LineCapStyle.Round,
   });
 
   // Lower-right quadrant

--- a/apps/rn/src/tests/test1.js
+++ b/apps/rn/src/tests/test1.js
@@ -156,7 +156,7 @@ export default async () => {
     borderDashArray: [25],
     borderDashPhase: 25,
     borderColor: cmyk(0, 1, 0, 0),
-    lineCap: LineCapStyle.Round,
+    borderLineCap: LineCapStyle.Round,
   });
 
   page1.drawLine({

--- a/apps/rn/src/tests/test12.js
+++ b/apps/rn/src/tests/test12.js
@@ -63,6 +63,7 @@ export default async () => {
     y: inchToPt(11),
     scale: 0.5,
     borderWidth: 2,
+    dashArray: [12, 6],
   });
   page2.drawSvgPath('M200,300 L400,50 L600,300 L800,550 L1000,300', {
     x: inchToPt(-1),

--- a/apps/rn/src/tests/test12.js
+++ b/apps/rn/src/tests/test12.js
@@ -1,6 +1,4 @@
-import { PageSizes, PDFDocument, rgb } from 'pdf-lib';
-
-import { fetchAsset } from './assets';
+import { PageSizes, PDFDocument, rgb, LineCapStyle } from 'pdf-lib';
 
 const inchToPt = (inches) => Math.round(inches * 72);
 
@@ -62,8 +60,9 @@ export default async () => {
     x: inchToPt(-1),
     y: inchToPt(11),
     scale: 0.5,
-    borderWidth: 2,
-    dashArray: [12, 6],
+    borderWidth: 4,
+    dashArray: [24, 12],
+    lineCap: LineCapStyle.Round,
   });
   page2.drawSvgPath('M200,300 L400,50 L600,300 L800,550 L1000,300', {
     x: inchToPt(-1),

--- a/apps/rn/src/tests/test12.js
+++ b/apps/rn/src/tests/test12.js
@@ -62,7 +62,7 @@ export default async () => {
     scale: 0.5,
     borderWidth: 4,
     borderDashArray: [24, 12],
-    lineCap: LineCapStyle.Round,
+    borderLineCap: LineCapStyle.Round,
   });
   page2.drawSvgPath('M200,300 L400,50 L600,300 L800,550 L1000,300', {
     x: inchToPt(-1),

--- a/apps/web/test1.html
+++ b/apps/web/test1.html
@@ -204,7 +204,7 @@
         borderDashArray: [25],
         borderDashPhase: 25,
         borderColor: cmyk(0, 1, 0, 0),
-        lineCap: LineCapStyle.Round,
+        borderLineCap: LineCapStyle.Round,
       });
 
       page1.drawLine({

--- a/apps/web/test1.html
+++ b/apps/web/test1.html
@@ -208,6 +208,20 @@
       });
       page1.pushOperators(popGraphicsState());
 
+      page1.drawLine({
+        start: {
+          x: size / 4,
+          y: size / 4
+        },
+        end: {
+          x: size / 4 + 100,
+          y: size / 4 + 100
+        },
+        color: rgb(0, 1, 0),
+        thickness: 3,
+        dashArray: [12, 12]
+      });
+
       // Lower-right quadrant
       page1.moveTo(size / 2, 0);
       page1.drawSquare({ size: size / 2, color: grayscale(0.8) });

--- a/apps/web/test1.html
+++ b/apps/web/test1.html
@@ -63,12 +63,10 @@
         clipEvenOdd,
         closePath,
         cmyk,
-        setDashPattern,
         degrees,
         drawRectangle,
         endPath,
         grayscale,
-        setLineCap,
         LineCapStyle,
         setLineJoin,
         LineJoinStyle,
@@ -196,10 +194,7 @@
       // Lower-left quadrant
       page1.moveTo(0, 0);
       page1.drawSquare({ size: size / 2, color: cmyk(1, 0, 0, 0) });
-      page1.pushOperators(
-        pushGraphicsState(),
-        setLineCap(LineCapStyle.Round),
-      );
+
       page1.drawCircle({
         x: size / 4,
         y: size / 4,
@@ -208,8 +203,8 @@
         dashArray: [25],
         dashPhase: 25,
         borderColor: cmyk(0, 1, 0, 0),
+        lineCap: LineCapStyle.Round,
       });
-      page1.pushOperators(popGraphicsState());
 
       page1.drawLine({
         start: {
@@ -223,6 +218,7 @@
         color: rgb(0, 1, 0),
         thickness: 3,
         dashArray: [12, 6],
+        lineCap: LineCapStyle.Round,
       });
 
       // Lower-right quadrant

--- a/apps/web/test1.html
+++ b/apps/web/test1.html
@@ -151,6 +151,8 @@
           xSkew: degrees(0),
           ySkew: degrees(0),
           color: undefined,
+          dashArray: [],
+          dashPhase: 0,
         }),
         popGraphicsState(),
       );
@@ -196,7 +198,6 @@
       page1.drawSquare({ size: size / 2, color: cmyk(1, 0, 0, 0) });
       page1.pushOperators(
         pushGraphicsState(),
-        setDashPattern([25], 25),
         setLineCap(LineCapStyle.Round),
       );
       page1.drawCircle({
@@ -204,6 +205,8 @@
         y: size / 4,
         size: 150,
         borderWidth: 10,
+        dashArray: [25],
+        dashPhase: 25,
         borderColor: cmyk(0, 1, 0, 0),
       });
       page1.pushOperators(popGraphicsState());
@@ -219,7 +222,7 @@
         },
         color: rgb(0, 1, 0),
         thickness: 3,
-        dashArray: [12, 12]
+        dashArray: [12, 6],
       });
 
       // Lower-right quadrant

--- a/apps/web/test12.html
+++ b/apps/web/test12.html
@@ -111,7 +111,7 @@
         scale: 0.5,
         borderWidth: 4,
         borderDashArray: [24, 12],
-        lineCap: LineCapStyle.Round,
+        borderLineCap: LineCapStyle.Round,
       });
       page2.drawSvgPath('M200,300 L400,50 L600,300 L800,550 L1000,300', {
         x: inchToPt(-1),

--- a/apps/web/test12.html
+++ b/apps/web/test12.html
@@ -50,7 +50,7 @@
     const inchToPt = (inches) => Math.round(inches * 72);
 
     async function test() {
-      const { PageSizes, PDFDocument, rgb } = PDFLib;
+      const { PageSizes, PDFDocument, rgb, LineCapStyle } = PDFLib;
 
       const pdfDoc = await PDFDocument.create();
 
@@ -109,8 +109,9 @@
         x: inchToPt(-1),
         y: inchToPt(11),
         scale: 0.5,
-        borderWidth: 2,
-        dashArray: [12, 6],
+        borderWidth: 4,
+        dashArray: [24, 12],
+        lineCap: LineCapStyle.Round,
       });
       page2.drawSvgPath('M200,300 L400,50 L600,300 L800,550 L1000,300', {
         x: inchToPt(-1),

--- a/apps/web/test12.html
+++ b/apps/web/test12.html
@@ -110,6 +110,7 @@
         y: inchToPt(11),
         scale: 0.5,
         borderWidth: 2,
+        dashArray: [12, 6],
       });
       page2.drawSvgPath('M200,300 L400,50 L600,300 L800,550 L1000,300', {
         x: inchToPt(-1),

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -1177,6 +1177,8 @@ export default class PDFPage {
     assertOrUndefined(options.thickness, 'options.thickness', ['number']);
     assertOrUndefined(options.color, 'options.color', [[Object, 'Color']]);
     // TODO: Should assert `options.lineCap` here, but is a breaking change
+    assertOrUndefined(options.dashArray, 'options.dashArray', [Array]);
+    assertOrUndefined(options.dashPhase, 'options.dashPhase', ['number']);
     assertOrUndefined(options.opacity, 'options.opacity', ['number']);
 
     const graphicsStateKey = this.maybeEmbedGraphicsState({
@@ -1193,6 +1195,8 @@ export default class PDFPage {
         start: options.start,
         end: options.end,
         thickness: options.thickness ?? 1,
+        dashArray: options.dashArray || [],
+        dashPhase: options.dashPhase ?? 0,
         color: options.color ?? undefined,
         lineCap: options.lineCap ?? undefined,
         graphicsState: graphicsStateKey,

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -1103,7 +1103,7 @@ export default class PDFPage {
    * })
    *
    * // Draw 50% of original size
-   *   page.drawSvgPath(svgPath, {
+   * page.drawSvgPath(svgPath, {
    *   x: 25,
    *   y: 675,
    *   scale: 0.5,

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -1126,6 +1126,7 @@ export default class PDFPage {
     assertOrUndefined(options.opacity, 'options.borderOpacity', ['number']);
     assertOrUndefined(options.dashArray, 'options.dashArray', [Array]);
     assertOrUndefined(options.dashPhase, 'options.dashPhase', ['number']);
+    assertOrUndefined(options.lineCap, 'options.lineCap', ['number']);
 
     const graphicsStateKey = this.maybeEmbedGraphicsState({
       opacity: options.opacity,
@@ -1147,6 +1148,7 @@ export default class PDFPage {
         borderWidth: options.borderWidth ?? 0,
         dashArray: options.dashArray || [],
         dashPhase: options.dashPhase ?? 0,
+        lineCap: options.lineCap ?? undefined,
         graphicsState: graphicsStateKey,
       }),
     );
@@ -1181,9 +1183,9 @@ export default class PDFPage {
     assertOrUndefined(options.thickness, 'options.thickness', ['number']);
     assertOrUndefined(options.color, 'options.color', [[Object, 'Color']]);
     assertOrUndefined(options.opacity, 'options.opacity', ['number']);
-    // TODO: Should assert `options.lineCap` here, but is a breaking change
     assertOrUndefined(options.dashArray, 'options.dashArray', [Array]);
     assertOrUndefined(options.dashPhase, 'options.dashPhase', ['number']);
+    assertOrUndefined(options.lineCap, 'options.lineCap', ['number']);
 
     const graphicsStateKey = this.maybeEmbedGraphicsState({
       borderOpacity: options.opacity,
@@ -1247,6 +1249,7 @@ export default class PDFPage {
     ]);
     assertOrUndefined(options.dashArray, 'options.dashArray', [Array]);
     assertOrUndefined(options.dashPhase, 'options.dashPhase', ['number']);
+    assertOrUndefined(options.lineCap, 'options.lineCap', ['number']);
 
     const graphicsStateKey = this.maybeEmbedGraphicsState({
       opacity: options.opacity,
@@ -1272,6 +1275,7 @@ export default class PDFPage {
         borderColor: options.borderColor ?? undefined,
         dashArray: options.dashArray || [],
         dashPhase: options.dashPhase ?? 0,
+        lineCap: options.lineCap ?? undefined,
         graphicsState: graphicsStateKey,
       }),
     );
@@ -1337,6 +1341,7 @@ export default class PDFPage {
     assertOrUndefined(options.borderWidth, 'options.borderWidth', ['number']);
     assertOrUndefined(options.dashArray, 'options.dashArray', [Array]);
     assertOrUndefined(options.dashPhase, 'options.dashPhase', ['number']);
+    assertOrUndefined(options.lineCap, 'options.lineCap', ['number']);
 
     const graphicsStateKey = this.maybeEmbedGraphicsState({
       opacity: options.opacity,
@@ -1359,6 +1364,7 @@ export default class PDFPage {
         borderWidth: options.borderWidth ?? 0,
         dashArray: options.dashArray || [],
         dashPhase: options.dashPhase ?? 0,
+        lineCap: options.lineCap ?? undefined,
         graphicsState: graphicsStateKey,
       }),
     );

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -1096,17 +1096,17 @@ export default class PDFPage {
    *
    * // Set fill color and opacity
    * page.drawSvgPath(svgPath, {
-   * 	 x: 25,
-   * 	 y: 475,
-   * 	 color: rgb(1.0, 0, 0),
+   *   x: 25,
+   *   y: 475,
+   *   color: rgb(1.0, 0, 0),
    *   opacity: 0.75,
    * })
    *
    * // Draw 50% of original size
-   * page.drawSvgPath(svgPath, {
-   * 	 x: 25,
-   * 	 y: 675,
-   * 	 scale: 0.5,
+   *   page.drawSvgPath(svgPath, {
+   *   x: 25,
+   *   y: 675,
+   *   scale: 0.5,
    * })
    * ```
    * @param path The SVG path to be drawn.

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -1124,6 +1124,8 @@ export default class PDFPage {
       [Object, 'Color'],
     ]);
     assertOrUndefined(options.opacity, 'options.borderOpacity', ['number']);
+    assertOrUndefined(options.dashArray, 'options.dashArray', [Array]);
+    assertOrUndefined(options.dashPhase, 'options.dashPhase', ['number']);
 
     const graphicsStateKey = this.maybeEmbedGraphicsState({
       opacity: options.opacity,
@@ -1143,6 +1145,8 @@ export default class PDFPage {
         color: options.color ?? undefined,
         borderColor: options.borderColor ?? undefined,
         borderWidth: options.borderWidth ?? 0,
+        dashArray: options.dashArray || [],
+        dashPhase: options.dashPhase ?? 0,
         graphicsState: graphicsStateKey,
       }),
     );
@@ -1176,10 +1180,10 @@ export default class PDFPage {
     assertIs(options.end.y, 'options.end.y', ['number']);
     assertOrUndefined(options.thickness, 'options.thickness', ['number']);
     assertOrUndefined(options.color, 'options.color', [[Object, 'Color']]);
+    assertOrUndefined(options.opacity, 'options.opacity', ['number']);
     // TODO: Should assert `options.lineCap` here, but is a breaking change
     assertOrUndefined(options.dashArray, 'options.dashArray', [Array]);
     assertOrUndefined(options.dashPhase, 'options.dashPhase', ['number']);
-    assertOrUndefined(options.opacity, 'options.opacity', ['number']);
 
     const graphicsStateKey = this.maybeEmbedGraphicsState({
       borderOpacity: options.opacity,
@@ -1195,9 +1199,9 @@ export default class PDFPage {
         start: options.start,
         end: options.end,
         thickness: options.thickness ?? 1,
+        color: options.color ?? undefined,
         dashArray: options.dashArray || [],
         dashPhase: options.dashPhase ?? 0,
-        color: options.color ?? undefined,
         lineCap: options.lineCap ?? undefined,
         graphicsState: graphicsStateKey,
       }),
@@ -1241,6 +1245,8 @@ export default class PDFPage {
     assertOrUndefined(options.borderOpacity, 'options.borderOpacity', [
       'number',
     ]);
+    assertOrUndefined(options.dashArray, 'options.dashArray', [Array]);
+    assertOrUndefined(options.dashPhase, 'options.dashPhase', ['number']);
 
     const graphicsStateKey = this.maybeEmbedGraphicsState({
       opacity: options.opacity,
@@ -1264,6 +1270,8 @@ export default class PDFPage {
         borderWidth: options.borderWidth ?? 0,
         color: options.color ?? undefined,
         borderColor: options.borderColor ?? undefined,
+        dashArray: options.dashArray || [],
+        dashPhase: options.dashPhase ?? 0,
         graphicsState: graphicsStateKey,
       }),
     );
@@ -1327,6 +1335,8 @@ export default class PDFPage {
       'number',
     ]);
     assertOrUndefined(options.borderWidth, 'options.borderWidth', ['number']);
+    assertOrUndefined(options.dashArray, 'options.dashArray', [Array]);
+    assertOrUndefined(options.dashPhase, 'options.dashPhase', ['number']);
 
     const graphicsStateKey = this.maybeEmbedGraphicsState({
       opacity: options.opacity,
@@ -1347,6 +1357,8 @@ export default class PDFPage {
         color: options.color ?? undefined,
         borderColor: options.borderColor ?? undefined,
         borderWidth: options.borderWidth ?? 0,
+        dashArray: options.dashArray || [],
+        dashPhase: options.dashPhase ?? 0,
         graphicsState: graphicsStateKey,
       }),
     );

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -1126,7 +1126,7 @@ export default class PDFPage {
     assertOrUndefined(options.opacity, 'options.borderOpacity', ['number']);
     assertOrUndefined(options.borderDashArray, 'options.borderDashArray', [Array]);
     assertOrUndefined(options.borderDashPhase, 'options.borderDashPhase', ['number']);
-    assertOrUndefined(options.lineCap, 'options.lineCap', ['number']);
+    assertOrUndefined(options.borderLineCap, 'options.borderLineCap', ['number']);
 
     const graphicsStateKey = this.maybeEmbedGraphicsState({
       opacity: options.opacity,
@@ -1148,7 +1148,7 @@ export default class PDFPage {
         borderWidth: options.borderWidth ?? 0,
         borderDashArray: options.borderDashArray ?? undefined,
         borderDashPhase: options.borderDashPhase ?? undefined,
-        lineCap: options.lineCap ?? undefined,
+        borderLineCap: options.borderLineCap ?? undefined,
         graphicsState: graphicsStateKey,
       }),
     );
@@ -1249,7 +1249,7 @@ export default class PDFPage {
     ]);
     assertOrUndefined(options.borderDashArray, 'options.borderDashArray', [Array]);
     assertOrUndefined(options.borderDashPhase, 'options.borderDashPhase', ['number']);
-    assertOrUndefined(options.lineCap, 'options.lineCap', ['number']);
+    assertOrUndefined(options.borderLineCap, 'options.borderLineCap', ['number']);
 
     const graphicsStateKey = this.maybeEmbedGraphicsState({
       opacity: options.opacity,
@@ -1276,7 +1276,7 @@ export default class PDFPage {
         borderDashArray: options.borderDashArray ?? undefined,
         borderDashPhase: options.borderDashPhase ?? undefined,
         graphicsState: graphicsStateKey,
-        lineCap: options.lineCap ?? undefined,
+        borderLineCap: options.borderLineCap ?? undefined,
       }),
     );
   }
@@ -1341,7 +1341,7 @@ export default class PDFPage {
     assertOrUndefined(options.borderWidth, 'options.borderWidth', ['number']);
     assertOrUndefined(options.borderDashArray, 'options.borderDashArray', [Array]);
     assertOrUndefined(options.borderDashPhase, 'options.borderDashPhase', ['number']);
-    assertOrUndefined(options.lineCap, 'options.lineCap', ['number']);
+    assertOrUndefined(options.borderLineCap, 'options.borderLineCap', ['number']);
 
     const graphicsStateKey = this.maybeEmbedGraphicsState({
       opacity: options.opacity,
@@ -1364,7 +1364,7 @@ export default class PDFPage {
         borderWidth: options.borderWidth ?? 0,
         borderDashArray: options.borderDashArray ?? undefined,
         borderDashPhase: options.borderDashPhase ?? undefined,
-        lineCap: options.lineCap ?? undefined,
+        borderLineCap: options.borderLineCap ?? undefined,
         graphicsState: graphicsStateKey,
       }),
     );

--- a/src/api/PDFPageOptions.ts
+++ b/src/api/PDFPageOptions.ts
@@ -53,6 +53,7 @@ export interface PDFPageDrawSVGOptions {
   borderOpacity?: number;
   dashArray?: number[];
   dashPhase?: number; 
+  lineCap?: LineCapStyle;
 }
 
 export interface PDFPageDrawLineOptions {
@@ -61,9 +62,9 @@ export interface PDFPageDrawLineOptions {
   thickness?: number;
   color?: Color;
   opacity?: number;
-  lineCap?: LineCapStyle;
   dashArray?: number[];
-  dashPhase?: number; 
+  dashPhase?: number;
+  lineCap?: LineCapStyle;
 }
 
 export interface PDFPageDrawRectangleOptions {
@@ -81,6 +82,7 @@ export interface PDFPageDrawRectangleOptions {
   borderOpacity?: number;
   dashArray?: number[];
   dashPhase?: number;
+  lineCap?: LineCapStyle;
 }
 
 export interface PDFPageDrawSquareOptions {
@@ -97,6 +99,7 @@ export interface PDFPageDrawSquareOptions {
   borderOpacity?: number;
   dashArray?: number[];
   dashPhase?: number;
+  lineCap?: LineCapStyle;
 }
 
 export interface PDFPageDrawEllipseOptions {
@@ -111,6 +114,7 @@ export interface PDFPageDrawEllipseOptions {
   borderWidth?: number;
   dashArray?: number[];
   dashPhase?: number;
+  lineCap?: LineCapStyle;
 }
 
 export interface PDFPageDrawCircleOptions {
@@ -124,4 +128,5 @@ export interface PDFPageDrawCircleOptions {
   borderWidth?: number;
   dashArray?: number[];
   dashPhase?: number;
+  lineCap?: LineCapStyle;
 }

--- a/src/api/PDFPageOptions.ts
+++ b/src/api/PDFPageOptions.ts
@@ -51,6 +51,8 @@ export interface PDFPageDrawSVGOptions {
   opacity?: number;
   borderColor?: Color;
   borderOpacity?: number;
+  dashArray?: number[];
+  dashPhase?: number; 
 }
 
 export interface PDFPageDrawLineOptions {
@@ -58,10 +60,10 @@ export interface PDFPageDrawLineOptions {
   end: { x: number; y: number };
   thickness?: number;
   color?: Color;
+  opacity?: number;
   lineCap?: LineCapStyle;
   dashArray?: number[];
   dashPhase?: number; 
-  opacity?: number;
 }
 
 export interface PDFPageDrawRectangleOptions {
@@ -77,6 +79,8 @@ export interface PDFPageDrawRectangleOptions {
   opacity?: number;
   borderColor?: Color;
   borderOpacity?: number;
+  dashArray?: number[];
+  dashPhase?: number;
 }
 
 export interface PDFPageDrawSquareOptions {
@@ -91,6 +95,8 @@ export interface PDFPageDrawSquareOptions {
   opacity?: number;
   borderColor?: Color;
   borderOpacity?: number;
+  dashArray?: number[];
+  dashPhase?: number;
 }
 
 export interface PDFPageDrawEllipseOptions {
@@ -103,6 +109,8 @@ export interface PDFPageDrawEllipseOptions {
   borderColor?: Color;
   borderOpacity?: number;
   borderWidth?: number;
+  dashArray?: number[];
+  dashPhase?: number;
 }
 
 export interface PDFPageDrawCircleOptions {
@@ -114,4 +122,6 @@ export interface PDFPageDrawCircleOptions {
   borderColor?: Color;
   borderOpacity?: number;
   borderWidth?: number;
+  dashArray?: number[];
+  dashPhase?: number;
 }

--- a/src/api/PDFPageOptions.ts
+++ b/src/api/PDFPageOptions.ts
@@ -59,6 +59,8 @@ export interface PDFPageDrawLineOptions {
   thickness?: number;
   color?: Color;
   lineCap?: LineCapStyle;
+  dashArray?: number[];
+  dashPhase?: number; 
   opacity?: number;
 }
 

--- a/src/api/PDFPageOptions.ts
+++ b/src/api/PDFPageOptions.ts
@@ -53,7 +53,7 @@ export interface PDFPageDrawSVGOptions {
   borderOpacity?: number;
   borderDashArray?: number[];
   borderDashPhase?: number; 
-  lineCap?: LineCapStyle;
+  borderLineCap?: LineCapStyle;
 }
 
 export interface PDFPageDrawLineOptions {
@@ -82,7 +82,7 @@ export interface PDFPageDrawRectangleOptions {
   borderOpacity?: number;
   borderDashArray?: number[];
   borderDashPhase?: number;
-  lineCap?: LineCapStyle;
+  borderLineCap?: LineCapStyle;
 }
 
 export interface PDFPageDrawSquareOptions {
@@ -99,7 +99,7 @@ export interface PDFPageDrawSquareOptions {
   borderOpacity?: number;
   borderDashArray?: number[];
   borderDashPhase?: number;
-  lineCap?: LineCapStyle;
+  borderLineCap?: LineCapStyle;
 }
 
 export interface PDFPageDrawEllipseOptions {
@@ -114,7 +114,7 @@ export interface PDFPageDrawEllipseOptions {
   borderWidth?: number;
   borderDashArray?: number[];
   borderDashPhase?: number;
-  lineCap?: LineCapStyle;
+  borderLineCap?: LineCapStyle;
 }
 
 export interface PDFPageDrawCircleOptions {
@@ -128,5 +128,5 @@ export interface PDFPageDrawCircleOptions {
   borderWidth?: number;
   borderDashArray?: number[];
   borderDashPhase?: number;
-  lineCap?: LineCapStyle;
+  borderLineCap?: LineCapStyle;
 }

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -152,8 +152,8 @@ export const drawLine = (options: {
   thickness: number | PDFNumber;
   color: Color | undefined;
   lineCap?: LineCapStyle;
-  dashArray: number[];
-  dashPhase: number;
+  dashArray: (number | PDFNumber)[];
+  dashPhase: number | PDFNumber;
   graphicsState?: string | PDFName;
 }) =>
   [
@@ -180,6 +180,8 @@ export const drawRectangle = (options: {
   rotate: Rotation;
   xSkew: Rotation;
   ySkew: Rotation;
+  dashArray: (number | PDFNumber)[];
+  dashPhase: number | PDFNumber;
   graphicsState?: string | PDFName;
 }) =>
   [
@@ -188,6 +190,7 @@ export const drawRectangle = (options: {
     options.color && setFillingColor(options.color),
     options.borderColor && setStrokingColor(options.borderColor),
     setLineWidth(options.borderWidth),
+    setDashPattern(options.dashArray, options.dashPhase),
     translate(options.x, options.y),
     rotateRadians(toRadians(options.rotate)),
     skewRadians(toRadians(options.xSkew), toRadians(options.ySkew)),
@@ -248,6 +251,8 @@ export const drawEllipse = (options: {
   color: Color | undefined;
   borderColor: Color | undefined;
   borderWidth: number | PDFNumber;
+  dashArray: (number | PDFNumber)[];
+  dashPhase: number | PDFNumber;
   graphicsState?: string | PDFName;
 }) =>
   [
@@ -256,6 +261,7 @@ export const drawEllipse = (options: {
     options.color && setFillingColor(options.color),
     options.borderColor && setStrokingColor(options.borderColor),
     setLineWidth(options.borderWidth),
+    setDashPattern(options.dashArray, options.dashPhase),
     ...drawEllipsePath({
       x: options.x,
       y: options.y,
@@ -281,6 +287,8 @@ export const drawSvgPath = (
     color: Color | undefined;
     borderColor: Color | undefined;
     borderWidth: number | PDFNumber;
+    dashArray: (number | PDFNumber)[];
+    dashPhase: number | PDFNumber;
     graphicsState?: string | PDFName;
   },
 ) =>
@@ -296,6 +304,8 @@ export const drawSvgPath = (
     options.color && setFillingColor(options.color),
     options.borderColor && setStrokingColor(options.borderColor),
     options.borderWidth && setLineWidth(options.borderWidth),
+
+    setDashPattern(options.dashArray, options.dashPhase),
 
     ...svgPathToOperators(path),
 

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -162,8 +162,8 @@ export const drawLine = (options: {
     options.color && setStrokingColor(options.color),
     setLineWidth(options.thickness),
     setDashPattern(options.dashArray, options.dashPhase),
-    moveTo(options.start.x, options.start.y),
     options.lineCap && setLineCap(options.lineCap),
+    moveTo(options.start.x, options.start.y),
     lineTo(options.end.x, options.end.y),
     stroke(),
     popGraphicsState(),
@@ -182,6 +182,7 @@ export const drawRectangle = (options: {
   ySkew: Rotation;
   dashArray: (number | PDFNumber)[];
   dashPhase: number | PDFNumber;
+  lineCap?: LineCapStyle;
   graphicsState?: string | PDFName;
 }) =>
   [
@@ -191,6 +192,7 @@ export const drawRectangle = (options: {
     options.borderColor && setStrokingColor(options.borderColor),
     setLineWidth(options.borderWidth),
     setDashPattern(options.dashArray, options.dashPhase),
+    options.lineCap && setLineCap(options.lineCap),
     translate(options.x, options.y),
     rotateRadians(toRadians(options.rotate)),
     skewRadians(toRadians(options.xSkew), toRadians(options.ySkew)),
@@ -254,6 +256,7 @@ export const drawEllipse = (options: {
   dashArray: (number | PDFNumber)[];
   dashPhase: number | PDFNumber;
   graphicsState?: string | PDFName;
+  lineCap?: LineCapStyle;
 }) =>
   [
     pushGraphicsState(),
@@ -261,6 +264,7 @@ export const drawEllipse = (options: {
     options.color && setFillingColor(options.color),
     options.borderColor && setStrokingColor(options.borderColor),
     setLineWidth(options.borderWidth),
+    options.lineCap && setLineCap(options.lineCap),
     setDashPattern(options.dashArray, options.dashPhase),
     ...drawEllipsePath({
       x: options.x,
@@ -289,6 +293,7 @@ export const drawSvgPath = (
     borderWidth: number | PDFNumber;
     dashArray: (number | PDFNumber)[];
     dashPhase: number | PDFNumber;
+    lineCap?: LineCapStyle;
     graphicsState?: string | PDFName;
   },
 ) =>
@@ -304,6 +309,7 @@ export const drawSvgPath = (
     options.color && setFillingColor(options.color),
     options.borderColor && setStrokingColor(options.borderColor),
     options.borderWidth && setLineWidth(options.borderWidth),
+    options.lineCap && setLineCap(options.lineCap),
 
     setDashPattern(options.dashArray, options.dashPhase),
 

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -181,7 +181,7 @@ export const drawRectangle = (options: {
   rotate: Rotation;
   xSkew: Rotation;
   ySkew: Rotation;
-  lineCap?: LineCapStyle;
+  borderLineCap?: LineCapStyle;
   borderDashArray?: (number | PDFNumber)[];
   borderDashPhase?: number | PDFNumber;
   graphicsState?: string | PDFName;
@@ -192,7 +192,7 @@ export const drawRectangle = (options: {
     options.color && setFillingColor(options.color),
     options.borderColor && setStrokingColor(options.borderColor),
     setLineWidth(options.borderWidth),
-    options.lineCap && setLineCap(options.lineCap),
+    options.borderLineCap && setLineCap(options.borderLineCap),
     setDashPattern(options.borderDashArray ?? [], options.borderDashPhase ?? 0),
     translate(options.x, options.y),
     rotateRadians(toRadians(options.rotate)),
@@ -257,7 +257,7 @@ export const drawEllipse = (options: {
   borderDashArray?: (number | PDFNumber)[];
   borderDashPhase?: number | PDFNumber;
   graphicsState?: string | PDFName;
-  lineCap?: LineCapStyle;
+  borderLineCap?: LineCapStyle;
 }) =>
   [
     pushGraphicsState(),
@@ -265,7 +265,7 @@ export const drawEllipse = (options: {
     options.color && setFillingColor(options.color),
     options.borderColor && setStrokingColor(options.borderColor),
     setLineWidth(options.borderWidth),
-    options.lineCap && setLineCap(options.lineCap),
+    options.borderLineCap && setLineCap(options.borderLineCap),
     setDashPattern(options.borderDashArray ?? [], options.borderDashPhase ?? 0),
     ...drawEllipsePath({
       x: options.x,
@@ -294,7 +294,7 @@ export const drawSvgPath = (
     borderWidth: number | PDFNumber;
     borderDashArray?: (number | PDFNumber)[];
     borderDashPhase?: number | PDFNumber;
-    lineCap?: LineCapStyle;
+    borderLineCap?: LineCapStyle;
     graphicsState?: string | PDFName;
   },
 ) =>
@@ -310,7 +310,7 @@ export const drawSvgPath = (
     options.color && setFillingColor(options.color),
     options.borderColor && setStrokingColor(options.borderColor),
     options.borderWidth && setLineWidth(options.borderWidth),
-    options.lineCap && setLineCap(options.lineCap),
+    options.borderLineCap && setLineCap(options.borderLineCap),
 
     setDashPattern(options.borderDashArray ?? [], options.borderDashPhase ?? 0),
 

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -26,6 +26,7 @@ import {
   LineCapStyle,
   setLineCap,
   setGraphicsState,
+  setDashPattern,
 } from 'src/api/operators';
 import { Rotation, toRadians } from 'src/api/rotations';
 import { svgPathToOperators } from 'src/api/svgPath';
@@ -151,6 +152,8 @@ export const drawLine = (options: {
   thickness: number | PDFNumber;
   color: Color | undefined;
   lineCap?: LineCapStyle;
+  dashArray: number[];
+  dashPhase: number;
   graphicsState?: string | PDFName;
 }) =>
   [
@@ -158,6 +161,7 @@ export const drawLine = (options: {
     options.graphicsState && setGraphicsState(options.graphicsState),
     options.color && setStrokingColor(options.color),
     setLineWidth(options.thickness),
+    setDashPattern(options.dashArray, options.dashPhase),
     moveTo(options.start.x, options.start.y),
     options.lineCap && setLineCap(options.lineCap),
     lineTo(options.end.x, options.end.y),


### PR DESCRIPTION
Similar to #498 , but for lineCap.

There was a comment from @Hopding , saying:
// TODO: Should assert `options.lineCap` here, but is a breaking change

I'm not sure why this would be a breaking change, we can just default to `LineCapStyle.Butt`, or we can ignore this parameter if it's not provided (like this PR does). Maybe there's more to it than I can see, so let me know! :)