### PR TITLE
Additional support for factur-x (PDF-A3)

### DIFF
--- a/src/api/PDFDocument.ts
+++ b/src/api/PDFDocument.ts
@@ -49,6 +49,7 @@ import { Fontkit } from 'src/types/fontkit';
 import { TransformationMatrix } from 'src/types/matrix';
 import {
   assertIs,
+  assertIsOneOfOrUndefined,
   assertOrUndefined,
   assertRange,
   Cache,
@@ -59,7 +60,7 @@ import {
   range,
   toUint8Array,
 } from 'src/utils';
-import FileEmbedder from 'src/core/embedders/FileEmbedder';
+import FileEmbedder, { AFRelationship } from 'src/core/embedders/FileEmbedder';
 import PDFEmbeddedFile from 'src/api/PDFEmbeddedFile';
 import PDFJavaScript from 'src/api/PDFJavaScript';
 import JavaScriptEmbedder from 'src/core/embedders/JavaScriptEmbedder';
@@ -820,6 +821,7 @@ export default class PDFDocument {
     assertOrUndefined(options.modificationDate, 'options.modificationDate', [
       Date,
     ]);
+    assertIsOneOfOrUndefined(options.afRelationship, 'options.afRelationship', AFRelationship);
 
     const bytes = toUint8Array(attachment);
     const embedder = FileEmbedder.for(bytes, name, options);

--- a/src/api/PDFEmbeddedFile.ts
+++ b/src/api/PDFEmbeddedFile.ts
@@ -70,6 +70,14 @@ export default class PDFEmbeddedFile implements Embeddable {
       EFNames.push(PDFHexString.fromText(this.embedder.fileName));
       EFNames.push(ref);
 
+      /**
+       * The AF-Tag is needed to achieve PDF-A3 compliance for embedded files
+       * 
+       * The following document outlines the uses cases of the associated files (AF) tag.
+       * See:
+       * https://www.pdfa.org/wp-content/uploads/2018/10/PDF20_AN002-AF.pdf
+       */
+
       if (!this.doc.catalog.has(PDFName.of('AF'))) {
         this.doc.catalog.set(PDFName.of('AF'), this.doc.context.obj([]));
       }

--- a/src/api/PDFEmbeddedFile.ts
+++ b/src/api/PDFEmbeddedFile.ts
@@ -70,6 +70,12 @@ export default class PDFEmbeddedFile implements Embeddable {
       EFNames.push(PDFHexString.fromText(this.embedder.fileName));
       EFNames.push(ref);
 
+      if (!this.doc.catalog.has(PDFName.of('AF'))) {
+        this.doc.catalog.set(PDFName.of('AF'), this.doc.context.obj([]));
+      }
+      const AF = this.doc.catalog.lookup(PDFName.of('AF'), PDFArray);
+      AF.push(ref)
+
       this.alreadyEmbedded = true;
     }
   }

--- a/src/core/PDFContext.ts
+++ b/src/core/PDFContext.ts
@@ -21,15 +21,15 @@ import { typedArrayFor } from 'src/utils';
 
 type LookupKey = PDFRef | PDFObject | undefined;
 
-interface LiteralObject {
+export interface LiteralObject {
   [name: string]: Literal | PDFObject;
 }
 
-interface LiteralArray {
+export interface LiteralArray {
   [index: number]: Literal | PDFObject;
 }
 
-type Literal =
+export type Literal =
   | LiteralObject
   | LiteralArray
   | string

--- a/src/core/PDFContext.ts
+++ b/src/core/PDFContext.ts
@@ -25,7 +25,7 @@ interface LiteralObject {
   [name: string]: Literal | PDFObject;
 }
 
-export interface LiteralArray {
+interface LiteralArray {
   [index: number]: Literal | PDFObject;
 }
 

--- a/src/core/PDFContext.ts
+++ b/src/core/PDFContext.ts
@@ -21,7 +21,7 @@ import { typedArrayFor } from 'src/utils';
 
 type LookupKey = PDFRef | PDFObject | undefined;
 
-export interface LiteralObject {
+interface LiteralObject {
   [name: string]: Literal | PDFObject;
 }
 

--- a/src/core/embedders/CustomFontEmbedder.ts
+++ b/src/core/embedders/CustomFontEmbedder.ts
@@ -136,6 +136,7 @@ class CustomFontEmbedder {
     const cidFontDict = context.obj({
       Type: 'Font',
       Subtype: this.isCFF() ? 'CIDFontType0' : 'CIDFontType2',
+      CIDToGIDMap: 'Identity',
       BaseFont: this.baseFontName,
       CIDSystemInfo: {
         Registry: PDFString.of('Adobe'),

--- a/src/core/embedders/FileEmbedder.ts
+++ b/src/core/embedders/FileEmbedder.ts
@@ -2,12 +2,14 @@ import PDFString from 'src/core/objects/PDFString';
 import PDFHexString from 'src/core/objects/PDFHexString';
 import PDFContext from 'src/core/PDFContext';
 import PDFRef from 'src/core/objects/PDFRef';
+import {LiteralObject} from 'src/core/PDFContext'
 
 export interface EmbeddedFileOptions {
   mimeType?: string;
   description?: string;
   creationDate?: Date;
   modificationDate?: Date;
+  additionalParams?: LiteralObject;
 }
 
 class FileEmbedder {
@@ -39,7 +41,9 @@ class FileEmbedder {
       description,
       creationDate,
       modificationDate,
+      additionalParams
     } = this.options;
+
 
     const embeddedFileStream = context.flateStream(this.fileData, {
       Type: 'EmbeddedFile',
@@ -62,6 +66,7 @@ class FileEmbedder {
       UF: PDFHexString.fromText(this.fileName),
       EF: { F: embeddedFileStreamRef },
       Desc: description ? PDFHexString.fromText(description) : undefined,
+      ...additionalParams
     });
 
     if (ref) {

--- a/src/core/embedders/FileEmbedder.ts
+++ b/src/core/embedders/FileEmbedder.ts
@@ -2,14 +2,29 @@ import PDFString from 'src/core/objects/PDFString';
 import PDFHexString from 'src/core/objects/PDFHexString';
 import PDFContext from 'src/core/PDFContext';
 import PDFRef from 'src/core/objects/PDFRef';
-import {LiteralObject} from 'src/core/PDFContext'
+
+/** 
+ * From the PDF-A3 specification, section **3.1. Requirements - General**.
+ * See:
+ * * https://www.pdfa.org/wp-content/uploads/2018/10/PDF20_AN002-AF.pdf
+ */
+export enum AFRelationship {
+  Source = 'Source',
+  Data = 'Data',
+  Alternative = 'Alternative',
+  Supplement = 'Supplement',
+  EncryptedPayload = 'EncryptedPayload',
+  FormData = 'EncryptedPayload',
+  Schema = 'Schema',
+  Unspecified = 'Unspecified'
+}
 
 export interface EmbeddedFileOptions {
   mimeType?: string;
   description?: string;
   creationDate?: Date;
   modificationDate?: Date;
-  additionalParams?: LiteralObject;
+  afRelationship?: AFRelationship;
 }
 
 class FileEmbedder {
@@ -41,7 +56,7 @@ class FileEmbedder {
       description,
       creationDate,
       modificationDate,
-      additionalParams
+      afRelationship
     } = this.options;
 
 
@@ -66,7 +81,7 @@ class FileEmbedder {
       UF: PDFHexString.fromText(this.fileName),
       EF: { F: embeddedFileStreamRef },
       Desc: description ? PDFHexString.fromText(description) : undefined,
-      ...additionalParams
+      AFRelationship: afRelationship ?? undefined
     });
 
     if (ref) {

--- a/src/core/objects/PDFArray.ts
+++ b/src/core/objects/PDFArray.ts
@@ -11,6 +11,7 @@ import PDFString from 'src/core/objects/PDFString';
 import PDFContext from 'src/core/PDFContext';
 import CharCodes from 'src/core/syntax/CharCodes';
 import { PDFArrayIsNotRectangleError } from 'src/core/errors';
+import PDFRawStream from './PDFRawStream';
 
 class PDFArray extends PDFObject {
   static withContext = (context: PDFContext) => new PDFArray(context);
@@ -59,6 +60,7 @@ class PDFArray extends PDFObject {
   lookupMaybe(index: number, type: typeof PDFNull): typeof PDFNull | undefined;
   lookupMaybe(index: number, type: typeof PDFNumber): PDFNumber | undefined;
   lookupMaybe(index: number, type: typeof PDFStream): PDFStream | undefined;
+  lookupMaybe(index: number, type: typeof PDFRawStream): PDFRawStream | undefined;
   lookupMaybe(index: number, type: typeof PDFRef): PDFRef | undefined;
   lookupMaybe(index: number, type: typeof PDFString): PDFString | undefined;
   lookupMaybe(

--- a/src/core/objects/PDFArray.ts
+++ b/src/core/objects/PDFArray.ts
@@ -11,7 +11,7 @@ import PDFString from 'src/core/objects/PDFString';
 import PDFContext from 'src/core/PDFContext';
 import CharCodes from 'src/core/syntax/CharCodes';
 import { PDFArrayIsNotRectangleError } from 'src/core/errors';
-import PDFRawStream from './PDFRawStream';
+import PDFRawStream from 'src/core/objects/PDFRawStream';
 
 class PDFArray extends PDFObject {
   static withContext = (context: PDFContext) => new PDFArray(context);

--- a/src/core/objects/PDFArray.ts
+++ b/src/core/objects/PDFArray.ts
@@ -86,6 +86,7 @@ class PDFArray extends PDFObject {
   lookup(index: number, type: typeof PDFNull): typeof PDFNull;
   lookup(index: number, type: typeof PDFNumber): PDFNumber;
   lookup(index: number, type: typeof PDFStream): PDFStream;
+  lookup(index: number, type: typeof PDFRawStream): PDFRawStream;
   lookup(index: number, type: typeof PDFRef): PDFRef;
   lookup(index: number, type: typeof PDFString): PDFString;
   lookup(


### PR DESCRIPTION
The factur-x (ZUGFeRD) standard needs the attached files listed in the AF-tag.
Furthermore, additional metadata is necessary for the embedded files.

Easy solution: Allow users to supply additionalParams.

To access the attached files of factur-x invoices, access to the PDFRawStream is needed.