### PR TITLE
Rotation for ellipse and svgPath

### DIFF
--- a/apps/deno/tests/test1.ts
+++ b/apps/deno/tests/test1.ts
@@ -113,6 +113,7 @@ export default async (assets: Assets) => {
     borderWidth: 2,
     borderColor: rgb(0, 1, 1),
     borderDashArray: [10],
+    rotate: degrees(30),
   });
   page1.drawEllipse({
     x: size / 2 + size / 4,

--- a/apps/deno/tests/test12.ts
+++ b/apps/deno/tests/test12.ts
@@ -69,13 +69,14 @@ const secondPage = async (pdfDoc: PDFDocument) => {
   const page = pdfDoc.addPage(PageSizes.Letter);
 
   // quadratic bezier example
-  page.drawSvgPath('M200,300 Q400,50 600,300 T1000,300', {
-    x: inchToPt(-1),
-    y: inchToPt(11),
+  page.drawSvgPath('M0,0 q100,125 100,0 T200,0', {
+    x: 100,
+    y: 700,
     scale: 0.5,
     borderWidth: 4,
     borderDashArray: [24, 12],
     borderLineCap: LineCapStyle.Round,
+    rotate: degrees(30),
   });
   page.drawSvgPath('M200,300 L400,50 L600,300 L800,550 L1000,300', {
     x: inchToPt(-1),

--- a/apps/deno/tests/test12.ts
+++ b/apps/deno/tests/test12.ts
@@ -69,7 +69,7 @@ const secondPage = async (pdfDoc: PDFDocument) => {
   const page = pdfDoc.addPage(PageSizes.Letter);
 
   // quadratic bezier example
-  page.drawSvgPath('M0,0 q100,125 100,0 T200,0', {
+  page.drawSvgPath('M200,300 Q400,50 600,300 T1000,300', {
     x: 100,
     y: 700,
     scale: 0.5,

--- a/apps/node/tests/test1.ts
+++ b/apps/node/tests/test1.ts
@@ -113,6 +113,7 @@ export default async (assets: Assets) => {
     borderWidth: 2,
     borderColor: rgb(0, 1, 1),
     borderDashArray: [10],
+    rotate: degrees(30),
   });
   page1.drawEllipse({
     x: size / 2 + size / 4,

--- a/apps/node/tests/test12.ts
+++ b/apps/node/tests/test12.ts
@@ -66,13 +66,14 @@ const secondPage = async (pdfDoc: PDFDocument) => {
   const page = pdfDoc.addPage(PageSizes.Letter);
 
   // quadratic bezier example
-  page.drawSvgPath('M200,300 Q400,50 600,300 T1000,300', {
-    x: inchToPt(-1),
-    y: inchToPt(11),
+  page.drawSvgPath('M0,0 q100,125 100,0 T200,0', {
+    x: 100,
+    y: 700,
     scale: 0.5,
     borderWidth: 4,
     borderDashArray: [24, 12],
     borderLineCap: LineCapStyle.Round,
+    rotate: degrees(30),
   });
   page.drawSvgPath('M200,300 L400,50 L600,300 L800,550 L1000,300', {
     x: inchToPt(-1),

--- a/apps/node/tests/test12.ts
+++ b/apps/node/tests/test12.ts
@@ -66,7 +66,7 @@ const secondPage = async (pdfDoc: PDFDocument) => {
   const page = pdfDoc.addPage(PageSizes.Letter);
 
   // quadratic bezier example
-  page.drawSvgPath('M0,0 q100,125 100,0 T200,0', {
+  page.drawSvgPath('M200,300 Q400,50 600,300 T1000,300', {
     x: 100,
     y: 700,
     scale: 0.5,

--- a/apps/rn/src/tests/test1.js
+++ b/apps/rn/src/tests/test1.js
@@ -118,6 +118,7 @@ export default async () => {
     borderWidth: 2,
     borderColor: rgb(0, 1, 1),
     borderDashArray: [10],
+    rotate: degrees(30),
   });
   page1.drawEllipse({
     x: size / 2 + size / 4,

--- a/apps/rn/src/tests/test12.js
+++ b/apps/rn/src/tests/test12.js
@@ -67,13 +67,14 @@ const secondPage = async (pdfDoc) => {
   const page = pdfDoc.addPage(PageSizes.Letter);
 
   // quadratic bezier example
-  page.drawSvgPath('M200,300 Q400,50 600,300 T1000,300', {
-    x: inchToPt(-1),
-    y: inchToPt(11),
+  page.drawSvgPath('M0,0 q100,125 100,0 T200,0', {
+    x: 100,
+    y: 700,
     scale: 0.5,
     borderWidth: 4,
     borderDashArray: [24, 12],
     borderLineCap: LineCapStyle.Round,
+    rotate: degrees(30),
   });
   page.drawSvgPath('M200,300 L400,50 L600,300 L800,550 L1000,300', {
     x: inchToPt(-1),

--- a/apps/rn/src/tests/test12.js
+++ b/apps/rn/src/tests/test12.js
@@ -67,7 +67,7 @@ const secondPage = async (pdfDoc) => {
   const page = pdfDoc.addPage(PageSizes.Letter);
 
   // quadratic bezier example
-  page.drawSvgPath('M0,0 q100,125 100,0 T200,0', {
+  page.drawSvgPath('M200,300 Q400,50 600,300 T1000,300', {
     x: 100,
     y: 700,
     scale: 0.5,

--- a/apps/web/test1.html
+++ b/apps/web/test1.html
@@ -166,6 +166,7 @@
         borderWidth: 2,
         borderColor: rgb(0, 1, 1),
         borderDashArray: [10],
+        rotate: degrees(45),
       });
       page1.drawEllipse({
         x: size / 2 + size / 4,

--- a/apps/web/test1.html
+++ b/apps/web/test1.html
@@ -168,6 +168,20 @@
         borderDashArray: [10],
         rotate: degrees(30),
       });
+      page1.drawEllipse({
+        x: size / 2 + size / 4,
+        y: size / 2 + size / 4,
+        xScale: 75,
+        yScale: 50,
+        color: undefined,
+      });
+      page1.drawEllipse({
+        x: size / 2 + size / 4,
+        y: size / 2 + size / 4,
+        xScale: 150,
+        yScale: 100,
+        color: undefined,
+      });
       page1.pushOperators(clipEvenOdd(), endPath());
       page1.setFont(timesRomanFont);
       page1.setFontColor(rgb(1, 0, 1));

--- a/apps/web/test1.html
+++ b/apps/web/test1.html
@@ -182,7 +182,7 @@
         yScale: 100,
         color: undefined,
       });
-      //page1.pushOperators(clipEvenOdd(), endPath());
+      page1.pushOperators(clipEvenOdd(), endPath());
       page1.setFont(timesRomanFont);
       page1.setFontColor(rgb(1, 0, 1));
       page1.setFontSize(32);

--- a/apps/web/test1.html
+++ b/apps/web/test1.html
@@ -166,21 +166,7 @@
         borderWidth: 2,
         borderColor: rgb(0, 1, 1),
         borderDashArray: [10],
-        rotate: degrees(45),
-      });
-      page1.drawEllipse({
-        x: size / 2 + size / 4,
-        y: size / 2 + size / 4,
-        xScale: 75,
-        yScale: 50,
-        color: undefined,
-      });
-      page1.drawEllipse({
-        x: size / 2 + size / 4,
-        y: size / 2 + size / 4,
-        xScale: 150,
-        yScale: 100,
-        color: undefined,
+        rotate: degrees(30),
       });
       page1.pushOperators(clipEvenOdd(), endPath());
       page1.setFont(timesRomanFont);

--- a/apps/web/test1.html
+++ b/apps/web/test1.html
@@ -182,7 +182,7 @@
         yScale: 100,
         color: undefined,
       });
-      page1.pushOperators(clipEvenOdd(), endPath());
+      //page1.pushOperators(clipEvenOdd(), endPath());
       page1.setFont(timesRomanFont);
       page1.setFontColor(rgb(1, 0, 1));
       page1.setFontSize(32);

--- a/apps/web/test12.html
+++ b/apps/web/test12.html
@@ -116,7 +116,7 @@
       const page = pdfDoc.addPage(PageSizes.Letter);
 
       // quadratic bezier example
-      page.drawSvgPath('M0,0 q100,125 100,0 T200,0', {
+      page.drawSvgPath('M200,300 Q400,50 600,300 T1000,300', {
         x: 100,
         y: 700,
         scale: 0.5,

--- a/apps/web/test12.html
+++ b/apps/web/test12.html
@@ -116,13 +116,13 @@
       const page = pdfDoc.addPage(PageSizes.Letter);
 
       // quadratic bezier example
-      page.drawSvgPath('M200,300 Q400,50 600,300 T1000,300', {
-        x: inchToPt(-1),
-        y: inchToPt(11),
-        scale: 0.5,
+      page.drawSvgPath('M0,0 q100,125 100,0 T200,0', {
+        x: 100,
+        y: 700,
         borderWidth: 4,
         borderDashArray: [24, 12],
         borderLineCap: LineCapStyle.Round,
+        rotate: degrees(-30),
       });
       page.drawSvgPath('M200,300 L400,50 L600,300 L800,550 L1000,300', {
         x: inchToPt(-1),

--- a/apps/web/test12.html
+++ b/apps/web/test12.html
@@ -119,10 +119,11 @@
       page.drawSvgPath('M0,0 q100,125 100,0 T200,0', {
         x: 100,
         y: 700,
+        scale: 0.5,
         borderWidth: 4,
         borderDashArray: [24, 12],
         borderLineCap: LineCapStyle.Round,
-        rotate: degrees(-30),
+        rotate: degrees(30),
       });
       page.drawSvgPath('M200,300 L400,50 L600,300 L800,550 L1000,300', {
         x: inchToPt(-1),

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -1427,9 +1427,8 @@ export default class PDFPage {
    * @param options The options to be used when drawing the ellipse.
    */
   drawCircle(options: PDFPageDrawCircleOptions = {}): void {
-    let { size } = options;
+    const { size = 100 } = options;
     assertOrUndefined(size, 'size', ['number']);
-    size = asNumber(size ?? 100);
     this.drawEllipse({ ...options, xScale: size, yScale: size });
   }
 

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -52,7 +52,6 @@ import {
   assertRangeOrUndefined,
   assertIsOneOfOrUndefined,
 } from 'src/utils';
-import {asNumber} from "./objects";
 
 /**
  * Represents a single page of a [[PDFDocument]].
@@ -1378,6 +1377,25 @@ export default class PDFPage {
     assertOrUndefined(options.borderColor, 'options.borderColor', [
       [Object, 'Color'],
     ]);
+    assertRangeOrUndefined(
+      options.borderOpacity,
+      'options.borderOpacity',
+      0,
+      1,
+    );
+    assertOrUndefined(options.borderWidth, 'options.borderWidth', ['number']);
+    assertOrUndefined(options.borderDashArray, 'options.borderDashArray', [
+      Array,
+    ]);
+    assertOrUndefined(options.borderDashPhase, 'options.borderDashPhase', [
+      'number',
+    ]);
+    assertIsOneOfOrUndefined(
+      options.borderLineCap,
+      'options.borderLineCap',
+      LineCapStyle,
+    );
+    assertIsOneOfOrUndefined(options.blendMode, 'options.blendMode', BlendMode);
     const graphicsStateKey = this.maybeEmbedGraphicsState({
       opacity: options.opacity,
       borderOpacity: options.borderOpacity,

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -1425,7 +1425,9 @@ export default class PDFPage {
       y: centerY,
       rotate: options.rotate,
       color: options.color,
+      opacity: options.opacity,
       borderColor: options.borderColor,
+      borderOpacity: options.borderOpacity,
       borderWidth: options.borderWidth,
       borderDashArray: options.borderDashArray,
       borderDashPhase: options.borderDashPhase,
@@ -1452,8 +1454,9 @@ export default class PDFPage {
    * @param options The options to be used when drawing the ellipse.
    */
   drawCircle(options: PDFPageDrawCircleOptions = {}): void {
-    const { size } = options;
+    let { size } = options;
     assertOrUndefined(size, 'size', ['number']);
+    size = asNumber(size ?? 100);
     this.drawEllipse({ ...options, xScale: size, yScale: size });
   }
 

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -1369,6 +1369,7 @@ export default class PDFPage {
     assertOrUndefined(options.y, 'options.y', ['number']);
     assertOrUndefined(options.xScale, 'options.xScale', ['number']);
     assertOrUndefined(options.yScale, 'options.yScale', ['number']);
+    assertOrUndefined(options.rotate, 'options.rotate', [[Object, 'Rotation']]);
     assertOrUndefined(options.color, 'options.color', [[Object, 'Color']]);
     assertRangeOrUndefined(options.opacity, 'opacity.opacity', 0, 1);
     assertOrUndefined(options.borderColor, 'options.borderColor', [
@@ -1411,6 +1412,7 @@ export default class PDFPage {
         y: options.y ?? this.y,
         xScale: options.xScale ?? 100,
         yScale: options.yScale ?? 100,
+        rotate: options.rotate ?? degrees(0),
         color: options.color ?? undefined,
         borderColor: options.borderColor ?? undefined,
         borderWidth: options.borderWidth ?? 0,

--- a/src/api/PDFPageOptions.ts
+++ b/src/api/PDFPageOptions.ts
@@ -129,6 +129,7 @@ export interface PDFPageDrawEllipseOptions {
   y?: number;
   xScale?: number;
   yScale?: number;
+  rotate?: Rotation;
   color?: Color;
   opacity?: number;
   borderColor?: Color;

--- a/src/api/PDFPageOptions.ts
+++ b/src/api/PDFPageOptions.ts
@@ -64,6 +64,7 @@ export interface PDFPageDrawSVGOptions {
   x?: number;
   y?: number;
   scale?: number;
+  rotate?: Rotation;
   borderWidth?: number;
   color?: Color;
   opacity?: number;

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -1,7 +1,5 @@
 import { Color, setFillingColor, setStrokingColor } from 'src/api/colors';
-import { asNumber } from 'src/api/objects';
 import {
-  appendBezierCurve,
   beginText,
   closePath,
   drawObject,
@@ -212,86 +210,12 @@ export const drawRectangle = (options: {
     popGraphicsState(),
   ].filter(Boolean) as PDFOperator[];
 
-const KAPPA = 4.0 * ((Math.sqrt(2) - 1.0) / 3.0);
-
-export const drawEllipsePath = (config: {
-  x: number | PDFNumber;
-  y: number | PDFNumber;
-  xScale: number | PDFNumber;
-  yScale: number | PDFNumber;
-  rotate: Rotation;
-}): PDFOperator[] => {
-  let x = asNumber(config.x);
-  let y = asNumber(config.y);
-  const xScale = asNumber(config.xScale);
-  const yScale = asNumber(config.yScale);
-
-  x -= xScale;
-  y -= yScale;
-
-  const ox = xScale * KAPPA;
-  const oy = yScale * KAPPA;
-  const xe = x + xScale * 2;
-  const ye = y + yScale * 2;
-  const xm = x + xScale;
-  const ym = y + yScale;
-
-  return [
-    pushGraphicsState(),
-    rotateRadians(toRadians(config.rotate)),
-    moveTo(x, ym),
-    appendBezierCurve(x, ym - oy, xm - ox, y, xm, y),
-    appendBezierCurve(xm + ox, y, xe, ym - oy, xe, ym),
-    appendBezierCurve(xe, ym + oy, xm + ox, ye, xm, ye),
-    appendBezierCurve(xm - ox, ye, x, ym + oy, x, ym),
-    popGraphicsState(),
-  ];
-};
-
-export const drawEllipse = (options: {
-  x: number | PDFNumber;
-  y: number | PDFNumber;
-  xScale: number | PDFNumber;
-  yScale: number | PDFNumber;
-  rotate: Rotation;
-  color: Color | undefined;
-  borderColor: Color | undefined;
-  borderWidth: number | PDFNumber;
-  borderDashArray?: (number | PDFNumber)[];
-  borderDashPhase?: number | PDFNumber;
-  graphicsState?: string | PDFName;
-  borderLineCap?: LineCapStyle;
-}) =>
-  [
-    pushGraphicsState(),
-    options.graphicsState && setGraphicsState(options.graphicsState),
-    options.color && setFillingColor(options.color),
-    options.borderColor && setStrokingColor(options.borderColor),
-    setLineWidth(options.borderWidth),
-    options.borderLineCap && setLineCap(options.borderLineCap),
-    setDashPattern(options.borderDashArray ?? [], options.borderDashPhase ?? 0),
-    ...drawEllipsePath({
-      x: options.x,
-      y: options.y,
-      xScale: options.xScale,
-      yScale: options.yScale,
-      rotate: options.rotate,
-    }),
-
-    // prettier-ignore
-    options.color && options.borderWidth ? fillAndStroke()
-  : options.color                      ? fill()
-  : options.borderColor                ? stroke()
-  : closePath(),
-
-    popGraphicsState(),
-  ].filter(Boolean) as PDFOperator[];
-
 export const drawSvgPath = (
   path: string,
   options: {
     x: number | PDFNumber;
     y: number | PDFNumber;
+    rotate: Rotation;
     scale: number | PDFNumber | undefined;
     color: Color | undefined;
     borderColor: Color | undefined;
@@ -307,6 +231,7 @@ export const drawSvgPath = (
     options.graphicsState && setGraphicsState(options.graphicsState),
 
     translate(options.x, options.y),
+    rotateRadians(toRadians(options.rotate)),
 
     // SVG path Y axis is opposite pdf-lib's
     options.scale ? scale(options.scale, -options.scale) : scale(1, -1),

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -214,7 +214,7 @@ export const drawRectangle = (options: {
 
 const KAPPA = 4.0 * ((Math.sqrt(2) - 1.0) / 3.0);
 
-export const drawEllipsePath = (config: {
+const drawEllipsePath = (config: {
   x: number | PDFNumber;
   y: number | PDFNumber;
   xScale: number | PDFNumber;

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -293,7 +293,7 @@ export const drawSvgPath = (
   options: {
     x: number | PDFNumber;
     y: number | PDFNumber;
-    rotate: Rotation;
+    rotate?: Rotation;
     scale: number | PDFNumber | undefined;
     color: Color | undefined;
     borderColor: Color | undefined;

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -214,14 +214,49 @@ export const drawRectangle = (options: {
 
 const KAPPA = 4.0 * ((Math.sqrt(2) - 1.0) / 3.0);
 
-const drawEllipsePath = (config: {
+/** @deprecated */
+export const drawEllipsePath = (config: {
   x: number | PDFNumber;
   y: number | PDFNumber;
   xScale: number | PDFNumber;
   yScale: number | PDFNumber;
   rotate?: Rotation;
-}): PDFOperator[] =>
-{
+}): PDFOperator[] => {
+  const centerX = asNumber(config.x);
+  const centerY = asNumber(config.y);
+  const xScale = asNumber(config.xScale);
+  const yScale = asNumber(config.yScale);
+
+  const x = -xScale;
+  const y = -yScale;
+
+  const ox = xScale * KAPPA;
+  const oy = yScale * KAPPA;
+  const xe = x + xScale * 2;
+  const ye = y + yScale * 2;
+  const xm = x + xScale;
+  const ym = y + yScale;
+
+  return [
+    pushGraphicsState(),
+    translate(centerX, centerY),
+    rotateRadians(toRadians(config.rotate ?? degrees(0))),
+    moveTo(x, ym),
+    appendBezierCurve(x, ym - oy, xm - ox, y, xm, y),
+    appendBezierCurve(xm + ox, y, xe, ym - oy, xe, ym),
+    appendBezierCurve(xe, ym + oy, xm + ox, ye, xm, ye),
+    appendBezierCurve(xm - ox, ye, x, ym + oy, x, ym),
+    popGraphicsState(),
+  ];
+};
+
+const drawEllipseCurves = (config: {
+  x: number | PDFNumber;
+  y: number | PDFNumber;
+  xScale: number | PDFNumber;
+  yScale: number | PDFNumber;
+  rotate?: Rotation;
+}): PDFOperator[] => {
   const centerX = asNumber(config.x);
   const centerY = asNumber(config.y);
   const xScale = asNumber(config.xScale);
@@ -270,7 +305,7 @@ export const drawEllipse = (options: {
     setLineWidth(options.borderWidth),
     options.borderLineCap && setLineCap(options.borderLineCap),
     setDashPattern(options.borderDashArray ?? [], options.borderDashPhase ?? 0),
-    ...drawEllipsePath({
+    ...drawEllipseCurves({
       x: options.x,
       y: options.y,
       xScale: options.xScale,

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -27,7 +27,7 @@ import {
   setDashPattern,
   appendBezierCurve,
 } from 'src/api/operators';
-import { Rotation, toRadians } from 'src/api/rotations';
+import { Rotation, toRadians, degrees } from 'src/api/rotations';
 import { svgPathToOperators } from 'src/api/svgPath';
 import { PDFHexString, PDFName, PDFNumber, PDFOperator } from 'src/core';
 import { asNumber } from 'src/api/objects';
@@ -239,7 +239,7 @@ export const drawEllipsePath = (config: {
 
   return [
     translate(centerX, centerY),
-    rotateRadians(toRadians(config.rotate)),
+    rotateRadians(toRadians(config.rotate ?? degrees(0))),
     moveTo(x, ym),
     appendBezierCurve(x, ym - oy, xm - ox, y, xm, y),
     appendBezierCurve(xm + ox, y, xe, ym - oy, xe, ym),
@@ -309,7 +309,7 @@ export const drawSvgPath = (
     options.graphicsState && setGraphicsState(options.graphicsState),
 
     translate(options.x, options.y),
-    rotateRadians(toRadians(options.rotate)),
+    rotateRadians(toRadians(options.rotate ?? degrees(0))),
 
     // SVG path Y axis is opposite pdf-lib's
     options.scale ? scale(options.scale, -options.scale) : scale(1, -1),

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -219,6 +219,7 @@ export const drawEllipsePath = (config: {
   y: number | PDFNumber;
   xScale: number | PDFNumber;
   yScale: number | PDFNumber;
+  rotate: Rotation;
 }): PDFOperator[] => {
   let x = asNumber(config.x);
   let y = asNumber(config.y);
@@ -237,6 +238,7 @@ export const drawEllipsePath = (config: {
 
   return [
     pushGraphicsState(),
+    rotateRadians(toRadians(config.rotate)),
     moveTo(x, ym),
     appendBezierCurve(x, ym - oy, xm - ox, y, xm, y),
     appendBezierCurve(xm + ox, y, xe, ym - oy, xe, ym),
@@ -251,6 +253,7 @@ export const drawEllipse = (options: {
   y: number | PDFNumber;
   xScale: number | PDFNumber;
   yScale: number | PDFNumber;
+  rotate: Rotation;
   color: Color | undefined;
   borderColor: Color | undefined;
   borderWidth: number | PDFNumber;
@@ -272,6 +275,7 @@ export const drawEllipse = (options: {
       y: options.y,
       xScale: options.xScale,
       yScale: options.yScale,
+      rotate: options.rotate,
     }),
 
     // prettier-ignore

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -30,7 +30,7 @@ import {
 import { Rotation, toRadians } from 'src/api/rotations';
 import { svgPathToOperators } from 'src/api/svgPath';
 import { PDFHexString, PDFName, PDFNumber, PDFOperator } from 'src/core';
-import {asNumber} from "./objects";
+import { asNumber } from 'src/api/objects';
 
 export interface DrawTextOptions {
   color: Color;

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -219,7 +219,7 @@ export const drawEllipsePath = (config: {
   y: number | PDFNumber;
   xScale: number | PDFNumber;
   yScale: number | PDFNumber;
-  rotate: Rotation;
+  rotate?: Rotation;
 }): PDFOperator[] =>
 {
   const centerX = asNumber(config.x);

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -243,8 +243,6 @@ export const drawSvgPath = (
 
     setDashPattern(options.borderDashArray ?? [], options.borderDashPhase ?? 0),
 
-    setDashPattern(options.borderDashArray ?? [], options.borderDashPhase ?? 0),
-
     ...svgPathToOperators(path),
 
     // prettier-ignore


### PR DESCRIPTION
This PR adds high-level support for rotating svgPaths, and ellipses.

Some notes for @Hopding :
- I couldn't figure out why the rotating didn't have any effect on the ellipse on my first attempt, but I went on, and implemented the same thing for svgPaths.

- For svgPaths, it worked as expected. So, as a workaround/fix, I've changed the ellipse-drawing method to use the `drawSvgPath` as well: it uses the same bezier curves as before, but they're now defined in the path string. I think it's even better this way, because the codebase got a little bit smaller (no need for the `drawEllipse` methods anymore).

- I've modified some tests: test1, and test12 now includes rotation for ellipse, and for svgPath respectively.

- There's a "break" in functionality though: in test1, when you create that "mask" effect for the text with the 2 ellipses. That no longer works as expected. There seems to be a pretty huge offset for some reason, but I couldn't figure out the solution. Some additional notes about this:

  - If I give proper colors to the ellipses (instead of undefined), they appear on the right position and size
  - If I change these 2 lines in `PDFPage.ts` from this:
  ```
  const x = -xScale;
  const y = -yScale;
  ```
  to this:
  ```
   const x = centerX - xScale;
   const y = centerY - yScale;
   ```
  Then the "mask" effect seems to be fine, but all the visible ellipses are having an offset. I think it must be related to something like a "context position" that is being (or needs to be) modified (with `page.moveTo`), or something. Because the original ellipse drawing methods used something like that. And this bring me to my last note:
  - I tried to create the same "mask" effect with rectangles instead of ellipses, but it didn't work for me neither with, nor without this PR. So I think it was already a quite unique, "hacky" (or at least low-level) solution before, that it only worked with ellipses.