### PR TITLE
Allow custom font name on embed

### DIFF
--- a/src/api/PDFDocument.ts
+++ b/src/api/PDFDocument.ts
@@ -792,20 +792,20 @@ export default class PDFDocument {
     font: StandardFonts | string | Uint8Array | ArrayBuffer,
     options: EmbedFontOptions = {},
   ): Promise<PDFFont> {
-    const { subset = false, customFontName = '' } = options;
+    const { subset = false, customName } = options;
 
     assertIs(font, 'font', ['string', Uint8Array, ArrayBuffer]);
     assertIs(subset, 'subset', ['boolean']);
 
     let embedder: CustomFontEmbedder | StandardFontEmbedder;
     if (isStandardFont(font)) {
-      embedder = StandardFontEmbedder.for(font);
+      embedder = StandardFontEmbedder.for(font, customName);
     } else if (canBeConvertedToUint8Array(font)) {
       const bytes = toUint8Array(font);
       const fontkit = this.assertFontkit();
       embedder = subset
-        ? await CustomFontSubsetEmbedder.for(fontkit, bytes, customFontName)
-        : await CustomFontEmbedder.for(fontkit, bytes, customFontName);
+        ? await CustomFontSubsetEmbedder.for(fontkit, bytes, customName)
+        : await CustomFontEmbedder.for(fontkit, bytes, customName);
     } else {
       throw new TypeError(
         '`font` must be one of `StandardFonts | string | Uint8Array | ArrayBuffer`',
@@ -827,15 +827,16 @@ export default class PDFDocument {
    * const helveticaFont = pdfDoc.embedFont(StandardFonts.Helvetica)
    * ```
    * @param font The standard font to be embedded.
+   * @param customName The name to be used when embedding the font.
    * @returns The embedded font.
    */
-  embedStandardFont(font: StandardFonts): PDFFont {
+  embedStandardFont(font: StandardFonts, customName?: string): PDFFont {
     assertIs(font, 'font', ['string']);
     if (!isStandardFont(font)) {
-      throw new TypeError('`font` must be one of type `StandardFontsr`');
+      throw new TypeError('`font` must be one of type `StandardFonts`');
     }
 
-    const embedder = StandardFontEmbedder.for(font);
+    const embedder = StandardFontEmbedder.for(font, customName);
 
     const ref = this.context.nextRef();
     const pdfFont = PDFFont.of(ref, this, embedder);

--- a/src/api/PDFDocument.ts
+++ b/src/api/PDFDocument.ts
@@ -792,7 +792,7 @@ export default class PDFDocument {
     font: StandardFonts | string | Uint8Array | ArrayBuffer,
     options: EmbedFontOptions = {},
   ): Promise<PDFFont> {
-    const { subset = false } = options;
+    const { subset = false, customFontName = '' } = options;
 
     assertIs(font, 'font', ['string', Uint8Array, ArrayBuffer]);
     assertIs(subset, 'subset', ['boolean']);
@@ -804,8 +804,8 @@ export default class PDFDocument {
       const bytes = toUint8Array(font);
       const fontkit = this.assertFontkit();
       embedder = subset
-        ? await CustomFontSubsetEmbedder.for(fontkit, bytes)
-        : await CustomFontEmbedder.for(fontkit, bytes);
+        ? await CustomFontSubsetEmbedder.for(fontkit, bytes, customFontName)
+        : await CustomFontEmbedder.for(fontkit, bytes, customFontName);
     } else {
       throw new TypeError(
         '`font` must be one of `StandardFonts | string | Uint8Array | ArrayBuffer`',

--- a/src/api/PDFDocumentOptions.ts
+++ b/src/api/PDFDocumentOptions.ts
@@ -33,5 +33,5 @@ export interface CreateOptions {
 
 export interface EmbedFontOptions {
   subset?: boolean;
-  customFontName?: string;
+  customName?: string;
 }

--- a/src/api/PDFDocumentOptions.ts
+++ b/src/api/PDFDocumentOptions.ts
@@ -33,5 +33,5 @@ export interface CreateOptions {
 
 export interface EmbedFontOptions {
   subset?: boolean;
-  customFontName?:  string;
+  customFontName?: string;
 }

--- a/src/api/PDFDocumentOptions.ts
+++ b/src/api/PDFDocumentOptions.ts
@@ -33,4 +33,5 @@ export interface CreateOptions {
 
 export interface EmbedFontOptions {
   subset?: boolean;
+  customFontName?:  string;
 }

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -1402,8 +1402,7 @@ export default class PDFPage {
       blendMode: options.blendMode,
     });
 
-    if (!('color' in options) && !('borderColor' in options))
-    {
+    if (!('color' in options) && !('borderColor' in options)) {
       options.color = rgb(0, 0, 0);
     }
 

--- a/src/core/embedders/CustomFontEmbedder.ts
+++ b/src/core/embedders/CustomFontEmbedder.ts
@@ -23,31 +23,27 @@ class CustomFontEmbedder {
   static async for(
     fontkit: Fontkit,
     fontData: Uint8Array,
-    customFontName?: string,
+    customName?: string,
   ) {
     const font = await fontkit.create(fontData);
-    return new CustomFontEmbedder(font, fontData, customFontName);
+    return new CustomFontEmbedder(font, fontData, customName);
   }
 
   readonly font: Font;
   readonly scale: number;
   readonly fontData: Uint8Array;
   readonly fontName: string;
-  readonly customFontName: string | undefined;
+  readonly customName: string | undefined;
 
   protected baseFontName: string;
   protected glyphCache: Cache<Glyph[]>;
 
-  protected constructor(
-    font: Font,
-    fontData: Uint8Array,
-    customFontName?: string,
-  ) {
+  protected constructor(font: Font, fontData: Uint8Array, customName?: string) {
     this.font = font;
     this.scale = 1000 / this.font.unitsPerEm;
     this.fontData = fontData;
     this.fontName = this.font.postscriptName || 'Font';
-    this.customFontName = customFontName;
+    this.customName = customName;
 
     this.baseFontName = '';
     this.glyphCache = Cache.populatedBy(this.allGlyphsInFontSortedById);
@@ -93,7 +89,7 @@ class CustomFontEmbedder {
   }
 
   embedIntoContext(context: PDFContext, ref?: PDFRef): Promise<PDFRef> {
-    this.baseFontName = this.customFontName || addRandomSuffix(this.fontName);
+    this.baseFontName = this.customName || addRandomSuffix(this.fontName);
     return this.embedFontDict(context, ref);
   }
 

--- a/src/core/embedders/CustomFontEmbedder.ts
+++ b/src/core/embedders/CustomFontEmbedder.ts
@@ -20,24 +20,26 @@ import {
  *   https://github.com/devongovett/pdfkit/blob/e71edab0dd4657b5a767804ba86c94c58d01fbca/lib/image/jpeg.coffee
  */
 class CustomFontEmbedder {
-  static async for(fontkit: Fontkit, fontData: Uint8Array) {
+  static async for(fontkit: Fontkit, fontData: Uint8Array, customFontName?: string) {
     const font = await fontkit.create(fontData);
-    return new CustomFontEmbedder(font, fontData);
+    return new CustomFontEmbedder(font, fontData, customFontName);
   }
 
   readonly font: Font;
   readonly scale: number;
   readonly fontData: Uint8Array;
   readonly fontName: string;
+  readonly customFontName: string | undefined;
 
   protected baseFontName: string;
   protected glyphCache: Cache<Glyph[]>;
 
-  protected constructor(font: Font, fontData: Uint8Array) {
+  protected constructor(font: Font, fontData: Uint8Array, customFontName?: string) {
     this.font = font;
     this.scale = 1000 / this.font.unitsPerEm;
     this.fontData = fontData;
     this.fontName = this.font.postscriptName || 'Font';
+    this.customFontName = customFontName;
 
     this.baseFontName = '';
     this.glyphCache = Cache.populatedBy(this.allGlyphsInFontSortedById);
@@ -83,7 +85,7 @@ class CustomFontEmbedder {
   }
 
   embedIntoContext(context: PDFContext, ref?: PDFRef): Promise<PDFRef> {
-    this.baseFontName = addRandomSuffix(this.fontName);
+    this.baseFontName = this.customFontName || addRandomSuffix(this.fontName);
     return this.embedFontDict(context, ref);
   }
 

--- a/src/core/embedders/CustomFontEmbedder.ts
+++ b/src/core/embedders/CustomFontEmbedder.ts
@@ -20,7 +20,11 @@ import {
  *   https://github.com/devongovett/pdfkit/blob/e71edab0dd4657b5a767804ba86c94c58d01fbca/lib/image/jpeg.coffee
  */
 class CustomFontEmbedder {
-  static async for(fontkit: Fontkit, fontData: Uint8Array, customFontName?: string) {
+  static async for(
+    fontkit: Fontkit,
+    fontData: Uint8Array,
+    customFontName?: string,
+  ) {
     const font = await fontkit.create(fontData);
     return new CustomFontEmbedder(font, fontData, customFontName);
   }
@@ -34,7 +38,11 @@ class CustomFontEmbedder {
   protected baseFontName: string;
   protected glyphCache: Cache<Glyph[]>;
 
-  protected constructor(font: Font, fontData: Uint8Array, customFontName?: string) {
+  protected constructor(
+    font: Font,
+    fontData: Uint8Array,
+    customFontName?: string,
+  ) {
     this.font = font;
     this.scale = 1000 / this.font.unitsPerEm;
     this.fontData = fontData;

--- a/src/core/embedders/CustomFontSubsetEmbedder.ts
+++ b/src/core/embedders/CustomFontSubsetEmbedder.ts
@@ -10,17 +10,17 @@ import { Cache, mergeUint8Arrays, toHexStringOfMinLength } from 'src/utils';
  *   https://github.com/devongovett/pdfkit/blob/e71edab0dd4657b5a767804ba86c94c58d01fbca/lib/image/jpeg.coffee
  */
 class CustomFontSubsetEmbedder extends CustomFontEmbedder {
-  static async for(fontkit: Fontkit, fontData: Uint8Array) {
+  static async for(fontkit: Fontkit, fontData: Uint8Array, customFontName?: string) {
     const font = await fontkit.create(fontData);
-    return new CustomFontSubsetEmbedder(font, fontData);
+    return new CustomFontSubsetEmbedder(font, fontData, customFontName);
   }
 
   private readonly subset: Subset;
   private readonly glyphs: Glyph[];
   private readonly glyphIdMap: Map<number, number>;
 
-  private constructor(font: Font, fontData: Uint8Array) {
-    super(font, fontData);
+  private constructor(font: Font, fontData: Uint8Array, customFontName?: string) {
+    super(font, fontData, customFontName);
 
     this.subset = this.font.createSubset();
     this.glyphs = [];

--- a/src/core/embedders/CustomFontSubsetEmbedder.ts
+++ b/src/core/embedders/CustomFontSubsetEmbedder.ts
@@ -10,7 +10,11 @@ import { Cache, mergeUint8Arrays, toHexStringOfMinLength } from 'src/utils';
  *   https://github.com/devongovett/pdfkit/blob/e71edab0dd4657b5a767804ba86c94c58d01fbca/lib/image/jpeg.coffee
  */
 class CustomFontSubsetEmbedder extends CustomFontEmbedder {
-  static async for(fontkit: Fontkit, fontData: Uint8Array, customFontName?: string) {
+  static async for(
+    fontkit: Fontkit,
+    fontData: Uint8Array,
+    customFontName?: string,
+  ) {
     const font = await fontkit.create(fontData);
     return new CustomFontSubsetEmbedder(font, fontData, customFontName);
   }
@@ -19,7 +23,11 @@ class CustomFontSubsetEmbedder extends CustomFontEmbedder {
   private readonly glyphs: Glyph[];
   private readonly glyphIdMap: Map<number, number>;
 
-  private constructor(font: Font, fontData: Uint8Array, customFontName?: string) {
+  private constructor(
+    font: Font,
+    fontData: Uint8Array,
+    customFontName?: string,
+  ) {
     super(font, fontData, customFontName);
 
     this.subset = this.font.createSubset();

--- a/src/core/embedders/StandardFontEmbedder.ts
+++ b/src/core/embedders/StandardFontEmbedder.ts
@@ -21,13 +21,14 @@ export interface Glyph {
  *   https://github.com/foliojs/pdfkit/blob/f91bdd61c164a72ea06be1a43dc0a412afc3925f/lib/font/afm.coffee
  */
 class StandardFontEmbedder {
-  static for = (fontName: FontNames) => new StandardFontEmbedder(fontName);
+  static for = (fontName: FontNames, customName?: string) =>
+    new StandardFontEmbedder(fontName, customName);
 
   readonly font: Font;
   readonly encoding: Encoding;
   readonly fontName: string;
 
-  private constructor(fontName: FontNames) {
+  private constructor(fontName: FontNames, customName?: string) {
     // prettier-ignore
     this.encoding = (
         fontName === FontNames.ZapfDingbats ? Encodings.ZapfDingbats
@@ -35,7 +36,7 @@ class StandardFontEmbedder {
       : Encodings.WinAnsi
     );
     this.font = Font.load(fontName);
-    this.fontName = this.font.FontName;
+    this.fontName = customName || this.font.FontName;
   }
 
   /**

--- a/src/core/embedders/StandardFontEmbedder.ts
+++ b/src/core/embedders/StandardFontEmbedder.ts
@@ -85,7 +85,6 @@ class StandardFontEmbedder {
   }
 
   embedIntoContext(context: PDFContext, ref?: PDFRef): PDFRef {
-    console.log(this.customName);
     const fontDict = context.obj({
       Type: 'Font',
       Subtype: 'Type1',

--- a/src/core/embedders/StandardFontEmbedder.ts
+++ b/src/core/embedders/StandardFontEmbedder.ts
@@ -27,6 +27,7 @@ class StandardFontEmbedder {
   readonly font: Font;
   readonly encoding: Encoding;
   readonly fontName: string;
+  readonly customName: string | undefined;
 
   private constructor(fontName: FontNames, customName?: string) {
     // prettier-ignore
@@ -36,7 +37,8 @@ class StandardFontEmbedder {
       : Encodings.WinAnsi
     );
     this.font = Font.load(fontName);
-    this.fontName = customName || this.font.FontName;
+    this.fontName = this.font.FontName;
+    this.customName = customName;
   }
 
   /**
@@ -83,10 +85,11 @@ class StandardFontEmbedder {
   }
 
   embedIntoContext(context: PDFContext, ref?: PDFRef): PDFRef {
+    console.log(this.customName);
     const fontDict = context.obj({
       Type: 'Font',
       Subtype: 'Type1',
-      BaseFont: this.font.FontName,
+      BaseFont: this.customName || this.fontName,
 
       Encoding:
         this.encoding === Encodings.WinAnsi ? 'WinAnsiEncoding' : undefined,

--- a/tests/api/PDFDocument.spec.ts
+++ b/tests/api/PDFDocument.spec.ts
@@ -128,8 +128,8 @@ describe(`PDFDocument`, () => {
     it(`serializes the same value on every save when using a custom font name`, async () => {
       const customFont = fs.readFileSync('assets/fonts/ubuntu/Ubuntu-B.ttf');
       const customName = 'Custom-Font-Name';
-      const pdfDoc1 = await PDFDocument.create();
-      const pdfDoc2 = await PDFDocument.create();
+      const pdfDoc1 = await PDFDocument.create({ updateMetadata: false });
+      const pdfDoc2 = await PDFDocument.create({ updateMetadata: false });
 
       pdfDoc1.registerFontkit(fontkit);
       pdfDoc2.registerFontkit(fontkit);

--- a/tests/api/PDFDocument.spec.ts
+++ b/tests/api/PDFDocument.spec.ts
@@ -1,3 +1,4 @@
+import fontkit from '@pdf-lib/fontkit';
 import fs from 'fs';
 import {
   EncryptedPDFError,
@@ -120,6 +121,43 @@ describe(`PDFDocument`, () => {
           throwOnInvalidObject: true,
         }),
       ).rejects.toEqual(expectedError);
+    });
+  });
+
+  describe(`embedFont() method`, () => {
+    it(`serializes the same value on every save when using a custom font name`, async () => {
+      const customFont = fs.readFileSync('assets/fonts/ubuntu/Ubuntu-B.ttf');
+      const customName = 'Custom-Font-Name';
+      const pdfDoc1 = await PDFDocument.create();
+      const pdfDoc2 = await PDFDocument.create();
+
+      pdfDoc1.registerFontkit(fontkit);
+      pdfDoc2.registerFontkit(fontkit);
+
+      await pdfDoc1.embedFont(customFont, { customName });
+      await pdfDoc2.embedFont(customFont, { customName });
+
+      const savedDoc1 = await pdfDoc1.save();
+      const savedDoc2 = await pdfDoc2.save();
+
+      expect(savedDoc1).toEqual(savedDoc2);
+    });
+
+    it(`does not serialize the same on save when not using a custom font name`, async () => {
+      const customFont = fs.readFileSync('assets/fonts/ubuntu/Ubuntu-B.ttf');
+      const pdfDoc1 = await PDFDocument.create();
+      const pdfDoc2 = await PDFDocument.create();
+
+      pdfDoc1.registerFontkit(fontkit);
+      pdfDoc2.registerFontkit(fontkit);
+
+      await pdfDoc1.embedFont(customFont);
+      await pdfDoc2.embedFont(customFont);
+
+      const savedDoc1 = await pdfDoc1.save();
+      const savedDoc2 = await pdfDoc2.save();
+
+      expect(savedDoc1).not.toEqual(savedDoc2);
     });
   });
 

--- a/tests/core/embedders/CustomFontEmbedder.spec.ts
+++ b/tests/core/embedders/CustomFontEmbedder.spec.ts
@@ -25,6 +25,16 @@ describe(`CustomFontEmbedder`, () => {
     expect(embedder.fontName).toBe('Ubuntu');
   });
 
+  it(`can set a custom font name`, async () => {
+    const customFontName = 'abc123';
+    const embedder = await CustomFontEmbedder.for(
+      fontkit,
+      new Uint8Array(ubuntuFont),
+      customFontName
+    );
+    expect(embedder.customFontName).toBe(customFontName);
+  });
+
   it(`can embed font dictionaries into PDFContexts without a predefined ref`, async () => {
     const context = PDFContext.create();
     const embedder = await CustomFontEmbedder.for(

--- a/tests/core/embedders/CustomFontEmbedder.spec.ts
+++ b/tests/core/embedders/CustomFontEmbedder.spec.ts
@@ -30,7 +30,7 @@ describe(`CustomFontEmbedder`, () => {
     const embedder = await CustomFontEmbedder.for(
       fontkit,
       new Uint8Array(ubuntuFont),
-      customFontName
+      customFontName,
     );
     expect(embedder.customFontName).toBe(customFontName);
   });

--- a/tests/core/embedders/CustomFontEmbedder.spec.ts
+++ b/tests/core/embedders/CustomFontEmbedder.spec.ts
@@ -26,13 +26,13 @@ describe(`CustomFontEmbedder`, () => {
   });
 
   it(`can set a custom font name`, async () => {
-    const customFontName = 'abc123';
+    const customName = 'abc123';
     const embedder = await CustomFontEmbedder.for(
       fontkit,
       new Uint8Array(ubuntuFont),
-      customFontName,
+      customName,
     );
-    expect(embedder.customFontName).toBe(customFontName);
+    expect(embedder.customName).toBe(customName);
   });
 
   it(`can embed font dictionaries into PDFContexts without a predefined ref`, async () => {

--- a/tests/core/embedders/StandardFontEmbedder.spec.ts
+++ b/tests/core/embedders/StandardFontEmbedder.spec.ts
@@ -18,6 +18,15 @@ describe(`StandardFontEmbedder`, () => {
     expect(embedder.fontName).toBe('Helvetica-Oblique');
   });
 
+  it(`can use a custom font name`, () => {
+    const customName = 'Roboto 2';
+    const embedder = StandardFontEmbedder.for(
+      FontNames.HelveticaOblique,
+      customName,
+    );
+    expect(embedder.fontName).toBe(customName);
+  });
+
   it(`can embed standard font dictionaries into PDFContexts without a predefined ref`, () => {
     const context = PDFContext.create();
     const embedder = StandardFontEmbedder.for(FontNames.Courier);

--- a/tests/core/embedders/StandardFontEmbedder.spec.ts
+++ b/tests/core/embedders/StandardFontEmbedder.spec.ts
@@ -24,7 +24,7 @@ describe(`StandardFontEmbedder`, () => {
       FontNames.HelveticaOblique,
       customName,
     );
-    expect(embedder.fontName).toBe(customName);
+    expect(embedder.customName).toBe(customName);
   });
 
   it(`can embed standard font dictionaries into PDFContexts without a predefined ref`, () => {


### PR DESCRIPTION
As discussed in #537 this allows the use of a custom font name so that we can have a predictive binary output when embedding fonts into the pdf. Happy to make any changes you deem necessary.