### PR TITLE
Add deterministic per-document RNG

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "@pdf-lib/standard-fonts": "^0.0.4",
     "@pdf-lib/upng": "^1.0.1",
     "pako": "^1.0.11",
+    "seedrandom": "^3.0.5",
     "tslib": "^1.11.1"
   },
   "devDependencies": {
@@ -94,6 +95,7 @@
     "@types/jest": "^26.0.0",
     "@types/node-fetch": "^2.5.7",
     "@types/pako": "^1.0.1",
+    "@types/seedrandom": "^2.4.28",
     "@zerollup/ts-transform-paths": "^1.7.18",
     "downlevel-dts": "^0.5.0",
     "flamebearer": "^1.1.3",

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -31,8 +31,11 @@ export const copyStringIntoBuffer = (
   return length;
 };
 
-export const addRandomSuffix = (prefix: string, suffixLength = 4) =>
-  `${prefix}-${Math.floor(Math.random() * 10 ** suffixLength)}`;
+export const addRandomSuffix = (
+  rng: () => number,
+  prefix: string,
+  suffixLength = 4,
+) => `${prefix}-${Math.floor(rng() * 10 ** suffixLength)}`;
 
 export const escapeRegExp = (str: string) =>
   str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');

--- a/tests/api/PDFDocument.spec.ts
+++ b/tests/api/PDFDocument.spec.ts
@@ -143,7 +143,7 @@ describe(`PDFDocument`, () => {
       expect(savedDoc1).toEqual(savedDoc2);
     });
 
-    it(`does not serialize the same on save when not using a custom font name`, async () => {
+    it(`does serialize the same on save when not using a custom font name`, async () => {
       const customFont = fs.readFileSync('assets/fonts/ubuntu/Ubuntu-B.ttf');
       const pdfDoc1 = await PDFDocument.create();
       const pdfDoc2 = await PDFDocument.create();
@@ -157,7 +157,7 @@ describe(`PDFDocument`, () => {
       const savedDoc1 = await pdfDoc1.save();
       const savedDoc2 = await pdfDoc2.save();
 
-      expect(savedDoc1).not.toEqual(savedDoc2);
+      expect(savedDoc1).toEqual(savedDoc2);
     });
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -813,6 +813,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/seedrandom@^2.4.28":
+  version "2.4.28"
+  resolved "https://registry.yarnpkg.com/@types/seedrandom/-/seedrandom-2.4.28.tgz#9ce8fa048c1e8c85cb71d7fe4d704e000226036f"
+  integrity sha512-SMA+fUwULwK7sd/ZJicUztiPs8F1yCPwF3O23Z9uQ32ME5Ha0NmDK9+QTsYE4O2tHXChzXomSWWeIhCnoN1LqA==
+
 "@types/stack-utils@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-1.0.1.tgz#0a851d3bd96498fa25c33ab7278ed3bd65f06c3e"
@@ -3609,6 +3614,11 @@ secure-compare@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/secure-compare/-/secure-compare-3.0.1.tgz#f1a0329b308b221fae37b9974f3d578d0ca999e3"
   integrity sha1-8aAymzCLIh+uN7mXTz1XjQypmeM=
+
+seedrandom@^3.0.5:
+  version "3.0.5"
+  resolved "https://registry.yarnpkg.com/seedrandom/-/seedrandom-3.0.5.tgz#54edc85c95222525b0c7a6f6b3543d8e0b3aa0a7"
+  integrity sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==
 
 "semver@2 || 3 || 4 || 5":
   version "5.7.1"


### PR DESCRIPTION
Fixes #537 
Uses seedrandom to create a seeded random number generator for every document instance. This leads to identical binary documents, if the same actions are executed in the same order.