### PR TITLE
Update references to Pika - must reference new name "Skypack"

### DIFF
--- a/README.md
+++ b/README.md
@@ -846,7 +846,7 @@ import {
   PDFDocument,
   StandardFonts,
   rgb,
-} from 'https://cdn.skypack.dev/pdf-lib@^1.6.0';
+} from 'https://cdn.skypack.dev/pdf-lib@^1.11.1';
 
 const pdfDoc = await PDFDocument.create();
 const timesRomanFont = await pdfDoc.embedFont(StandardFonts.TimesRoman);
@@ -885,7 +885,7 @@ import {
   PDFDocument,
   rgb,
   StandardFonts,
-} from 'https://cdn.skypack.dev/pdf-lib@^1.6.0';
+} from 'https://cdn.skypack.dev/pdf-lib@^1.11.1';
 import fontkit from 'https://cdn.skypack.dev/@pdf-lib/fontkit@^1.0.0';
 
 const url = 'https://pdf-lib.js.org/assets/ubuntu/Ubuntu-R.ttf';

--- a/README.md
+++ b/README.md
@@ -833,7 +833,7 @@ const pdfBytes = await pdfDoc.save()
 
 ## Deno Usage
 
-`pdf-lib` fully supports the exciting new [Deno](https://deno.land/) runtime! All of the [usage examples](#usage-examples) work in Deno. The only thing you need to do is change the imports for `pdf-lib` and `@pdf-lib/fontkit` to use the [Pika](https://www.pika.dev/) CDN, because Deno requires all modules to be referenced via URLs.
+`pdf-lib` fully supports the exciting new [Deno](https://deno.land/) runtime! All of the [usage examples](#usage-examples) work in Deno. The only thing you need to do is change the imports for `pdf-lib` and `@pdf-lib/fontkit` to use the [Skypack](https://www.skypack.dev/) CDN, because Deno requires all modules to be referenced via URLs.
 
 > **See also [How to Create and Modify PDF Files in Deno With pdf-lib](https://medium.com/swlh/how-to-create-and-modify-pdf-files-in-deno-ffaad7099b0?source=friends_link&sk=3da183bb776d059df428eaea52102f19)**
 
@@ -846,7 +846,7 @@ import {
   PDFDocument,
   StandardFonts,
   rgb,
-} from 'https://cdn.pika.dev/pdf-lib@^1.6.0';
+} from 'https://cdn.skypack.dev/pdf-lib@^1.6.0';
 
 const pdfDoc = await PDFDocument.create();
 const timesRomanFont = await pdfDoc.embedFont(StandardFonts.TimesRoman);
@@ -885,8 +885,8 @@ import {
   PDFDocument,
   rgb,
   StandardFonts,
-} from 'https://cdn.pika.dev/pdf-lib@^1.6.0';
-import fontkit from 'https://cdn.pika.dev/@pdf-lib/fontkit@^1.0.0';
+} from 'https://cdn.skypack.dev/pdf-lib@^1.6.0';
+import fontkit from 'https://cdn.skypack.dev/@pdf-lib/fontkit@^1.0.0';
 
 const url = 'https://pdf-lib.js.org/assets/ubuntu/Ubuntu-R.ttf';
 const fontBytes = await fetch(url).then((res) => res.arrayBuffer());

--- a/README.md
+++ b/README.md
@@ -846,7 +846,7 @@ import {
   PDFDocument,
   StandardFonts,
   rgb,
-} from 'https://cdn.skypack.dev/pdf-lib@^1.11.1';
+} from 'https://cdn.skypack.dev/pdf-lib@^1.11.1?dts';
 
 const pdfDoc = await PDFDocument.create();
 const timesRomanFont = await pdfDoc.embedFont(StandardFonts.TimesRoman);
@@ -885,8 +885,8 @@ import {
   PDFDocument,
   rgb,
   StandardFonts,
-} from 'https://cdn.skypack.dev/pdf-lib@^1.11.1';
-import fontkit from 'https://cdn.skypack.dev/@pdf-lib/fontkit@^1.0.0';
+} from 'https://cdn.skypack.dev/pdf-lib@^1.11.1?dts';
+import fontkit from 'https://cdn.skypack.dev/@pdf-lib/fontkit@^1.0.0?dts';
 
 const url = 'https://pdf-lib.js.org/assets/ubuntu/Ubuntu-R.ttf';
 const fontBytes = await fetch(url).then((res) => res.arrayBuffer());

--- a/apps/deno/tests/test1.ts
+++ b/apps/deno/tests/test1.ts
@@ -1,4 +1,4 @@
-import fontkit from 'https://cdn.pika.dev/@pdf-lib/fontkit@^1.0.0';
+import fontkit from 'https://cdn.skypack.dev/@pdf-lib/fontkit@^1.0.0';
 import { Assets } from '../index.ts';
 import {
   clip,

--- a/apps/deno/tests/test1.ts
+++ b/apps/deno/tests/test1.ts
@@ -1,4 +1,4 @@
-import fontkit from 'https://cdn.skypack.dev/@pdf-lib/fontkit@^1.0.0';
+import fontkit from 'https://cdn.skypack.dev/@pdf-lib/fontkit@^1.0.0?dts';
 import { Assets } from '../index.ts';
 import {
   clip,

--- a/apps/deno/tests/test11.ts
+++ b/apps/deno/tests/test11.ts
@@ -1,4 +1,4 @@
-import fontkit from 'https://cdn.skypack.dev/@pdf-lib/fontkit@^1.0.0';
+import fontkit from 'https://cdn.skypack.dev/@pdf-lib/fontkit@^1.0.0?dts';
 import { Assets } from '../index.ts';
 import {
   last,

--- a/apps/deno/tests/test11.ts
+++ b/apps/deno/tests/test11.ts
@@ -1,4 +1,4 @@
-import fontkit from 'https://cdn.pika.dev/@pdf-lib/fontkit@^1.0.0';
+import fontkit from 'https://cdn.skypack.dev/@pdf-lib/fontkit@^1.0.0';
 import { Assets } from '../index.ts';
 import {
   last,

--- a/apps/deno/tests/test17.ts
+++ b/apps/deno/tests/test17.ts
@@ -1,4 +1,4 @@
-import fontkit from 'https://cdn.skypack.dev/@pdf-lib/fontkit@^1.0.0';
+import fontkit from 'https://cdn.skypack.dev/@pdf-lib/fontkit@^1.0.0?dts';
 
 import { Assets } from '../index.ts';
 import {

--- a/apps/deno/tests/test17.ts
+++ b/apps/deno/tests/test17.ts
@@ -1,4 +1,4 @@
-import fontkit from 'https://cdn.pika.dev/@pdf-lib/fontkit@^1.0.0';
+import fontkit from 'https://cdn.skypack.dev/@pdf-lib/fontkit@^1.0.0';
 
 import { Assets } from '../index.ts';
 import {

--- a/apps/deno/tests/test2.ts
+++ b/apps/deno/tests/test2.ts
@@ -1,4 +1,4 @@
-import fontkit from 'https://cdn.skypack.dev/@pdf-lib/fontkit@^1.0.0';
+import fontkit from 'https://cdn.skypack.dev/@pdf-lib/fontkit@^1.0.0?dts';
 import { Assets } from '../index.ts';
 import {
   ParseSpeeds,

--- a/apps/deno/tests/test2.ts
+++ b/apps/deno/tests/test2.ts
@@ -1,4 +1,4 @@
-import fontkit from 'https://cdn.pika.dev/@pdf-lib/fontkit@^1.0.0';
+import fontkit from 'https://cdn.skypack.dev/@pdf-lib/fontkit@^1.0.0';
 import { Assets } from '../index.ts';
 import {
   ParseSpeeds,

--- a/apps/deno/tests/test6.ts
+++ b/apps/deno/tests/test6.ts
@@ -1,4 +1,4 @@
-import fontkit from 'https://cdn.pika.dev/@pdf-lib/fontkit@^1.0.0';
+import fontkit from 'https://cdn.skypack.dev/@pdf-lib/fontkit@^1.0.0';
 import { Assets } from '../index.ts';
 import {
   degrees,

--- a/apps/deno/tests/test6.ts
+++ b/apps/deno/tests/test6.ts
@@ -1,4 +1,4 @@
-import fontkit from 'https://cdn.skypack.dev/@pdf-lib/fontkit@^1.0.0';
+import fontkit from 'https://cdn.skypack.dev/@pdf-lib/fontkit@^1.0.0?dts';
 import { Assets } from '../index.ts';
 import {
   degrees,

--- a/apps/deno/tests/test9.ts
+++ b/apps/deno/tests/test9.ts
@@ -1,4 +1,4 @@
-import fontkit from 'https://cdn.skypack.dev/@pdf-lib/fontkit@^1.0.0';
+import fontkit from 'https://cdn.skypack.dev/@pdf-lib/fontkit@^1.0.0?dts';
 import { Assets } from '../index.ts';
 import {
   ParseSpeeds,

--- a/apps/deno/tests/test9.ts
+++ b/apps/deno/tests/test9.ts
@@ -1,4 +1,4 @@
-import fontkit from 'https://cdn.pika.dev/@pdf-lib/fontkit@^1.0.0';
+import fontkit from 'https://cdn.skypack.dev/@pdf-lib/fontkit@^1.0.0';
 import { Assets } from '../index.ts';
 import {
   ParseSpeeds,


### PR DESCRIPTION
I was working on getting a proof-of-concept deno app using this library up and running and ran into the issue that pika.dev is now skypack.dev and will not allow new dependencies that point to their old domain name. You can read more at this [deprecation notice](https://www.pika.dev/cdn?skypack), which you now get instead of the code you requested when going to a cdn.pika.dev URL.

While I had the library open, I figured I would help future developers who would run into the same issue if they tried to cargo-cult your sample code. This PR swaps the references in the README and the deno tests to now point at skypack.