### PR TITLE
Add high-level API for adding document JavaScripts

### DIFF
--- a/apps/deno/tests/test1.ts
+++ b/apps/deno/tests/test1.ts
@@ -67,6 +67,11 @@ export default async (assets: Assets) => {
 
   const size = 750;
 
+  pdfDoc.addJavascript(
+    'main',
+    'console.show(); console.println("Hello World!")',
+  );
+
   /********************** Page 1 **********************/
 
   // This page tests different drawing operations as well as adding custom

--- a/apps/node/tests/test1.ts
+++ b/apps/node/tests/test1.ts
@@ -67,6 +67,11 @@ export default async (assets: Assets) => {
 
   const size = 750;
 
+  pdfDoc.addJavascript(
+    'main',
+    'console.show(); console.println("Hello World!")',
+  );
+
   /********************** Page 1 **********************/
 
   // This page tests different drawing operations as well as adding custom

--- a/apps/rn/src/tests/test1.js
+++ b/apps/rn/src/tests/test1.js
@@ -72,6 +72,11 @@ export default async () => {
 
   const size = 750;
 
+  pdfDoc.addJavascript(
+    'main',
+    'console.show(); console.println("Hello World!")',
+  );
+
   /********************** Page 1 **********************/
 
   // This page tests different drawing operations as well as adding custom

--- a/apps/web/test1.html
+++ b/apps/web/test1.html
@@ -120,6 +120,11 @@
 
       const size = 750;
 
+      pdfDoc.addJavascript(
+        'main',
+        'console.show(); console.println("Hello World!")',
+      );
+
       /********************** Page 1 **********************/
 
       // This page tests different drawing operations as well as adding custom

--- a/src/api/PDFDocument.ts
+++ b/src/api/PDFDocument.ts
@@ -716,11 +716,15 @@ export default class PDFDocument {
   /**
    * Add document JavaScript. The script is executed when the document is opened.
    * See the [JavaScript™ for Acrobat® API Reference](https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/js_api_reference.pdf)
-   * for details.
-   * @param script The JavaScript to execute.
+   * for details. For example:
+   *
+   * ```js
+   * pdfDoc.addJavascript('main', 'console.show(); console.println("Hello World")');
+   * ```
    * @param name The name of the script. Must be unique per document.
+   * @param script The JavaScript to execute.
    */
-  addJavascript(script: string, name: string) {
+  addJavascript(name: string, script: string) {
     const jsActionDict = this.context.obj({
       Type: 'Action',
       S: 'JavaScript',

--- a/src/api/PDFDocument.ts
+++ b/src/api/PDFDocument.ts
@@ -714,6 +714,29 @@ export default class PDFDocument {
   }
 
   /**
+   * Add document JavaScript. The script is executed when the document is opened.
+   * See the [JavaScript™ for Acrobat® API Reference](https://www.adobe.com/content/dam/acom/en/devnet/acrobat/pdfs/js_api_reference.pdf)
+   * for details.
+   * @param script The JavaScript to execute.
+   * @param name The name of the script. Must be unique per document.
+   */
+  addJavascript(script: string, name: string) {
+    const jsActionDict = this.context.obj({
+      Type: 'Action',
+      S: 'JavaScript',
+      JS: PDFHexString.fromText(script),
+    });
+    const jsActionRef = this.context.register(jsActionDict);
+    const jsNameTree = this.context.obj({
+      Names: this.context.obj([name, jsActionRef]),
+    });
+    this.catalog.set(
+      PDFName.of('Names'),
+      this.context.obj({ JavaScript: jsNameTree }),
+    );
+  }
+
+  /**
    * Add an attachment to this document. Attachments are visible in the
    * "Attachments" panel of Adobe Acrobat and some other PDF readers. Any
    * type of file can be added as an attachment. This includes, but is not


### PR DESCRIPTION
This PR adds an API for adding JavaScript to a document. It is based on [this issue](https://github.com/Hopding/pdf-lib/issues/477)).
