### PR TITLE
Support hexadecimal Default Appearance

### DIFF
--- a/src/core/acroform/PDFAcroField.ts
+++ b/src/core/acroform/PDFAcroField.ts
@@ -87,7 +87,12 @@ class PDFAcroField {
   }
 
   getDefaultAppearance(): string | undefined {
-    return this.DA()?.asString() ?? '';
+    const DA = this.DA();
+    if (DA instanceof PDFHexString) {
+      return DA.decodeText();
+    }
+
+    return DA?.asString();
   }
 
   getFlags(): number {

--- a/src/core/annotation/PDFWidgetAnnotation.ts
+++ b/src/core/annotation/PDFWidgetAnnotation.ts
@@ -45,7 +45,12 @@ class PDFWidgetAnnotation extends PDFAnnotation {
   }
 
   getDefaultAppearance(): string | undefined {
-    return this.DA()?.asString() ?? '';
+    const DA = this.DA();
+    if (DA instanceof PDFHexString) {
+      return DA.decodeText();
+    }
+
+    return DA?.asString();
   }
 
   getAppearanceCharacteristics(): AppearanceCharacteristics | undefined {


### PR DESCRIPTION
`getDefaultAppearance` is used to determine font size and the style among other things.
Some pdf files can have the `DA` property as a hexadecimal, causing the library to have a un-parsable `DA` value.

Bonus: Make return value match the function signature (`string | undefined`).