### PR TITLE
Add option to PDFDocument.setTitle to display the title in PDF readers

### DIFF
--- a/scratchpad/index.ts
+++ b/scratchpad/index.ts
@@ -6,83 +6,18 @@ import { PDFDocument } from 'src/index';
   // Create a new PDFDocument
   const pdfDoc = await PDFDocument.create();
 
+  // Set the title and include the new option.
+  pdfDoc.setTitle('Scratchpad Test Doc', { documentDisplayTitle: true })
+
   // Add a blank page to the document
   const page = pdfDoc.addPage([550, 750]);
 
-  // Get the form so we can add fields to it
-  const form = pdfDoc.getForm();
+  // Manual test...
+  page.drawText(`The window's title should match what we set in the metadata.`, { x: 15, y: 400, size: 15 });
 
-  // Add the superhero text field and description
-  page.drawText('Enter your favorite superhero:', { x: 50, y: 700, size: 20 });
-
-  const superheroField = form.createTextField('favorite.superhero');
-  superheroField.setText('One Punch Man');
-  superheroField.addToPage(page, { x: 55, y: 640 });
-
-  // Add the rocket radio group, labels, and description
-  page.drawText('Select your favorite rocket:', { x: 50, y: 600, size: 20 });
-
-  page.drawText('Falcon Heavy', { x: 120, y: 560, size: 18 });
-  page.drawText('Saturn IV', { x: 120, y: 500, size: 18 });
-  page.drawText('Delta IV Heavy', { x: 340, y: 560, size: 18 });
-  page.drawText('Space Launch System', { x: 340, y: 500, size: 18 });
-
-  const rocketField = form.createRadioGroup('favorite.rocket');
-  rocketField.addOptionToPage('Falcon Heavy', page, { x: 55, y: 540 });
-  rocketField.addOptionToPage('Saturn IV', page, { x: 55, y: 480 });
-  rocketField.addOptionToPage('Delta IV Heavy', page, { x: 275, y: 540 });
-  rocketField.addOptionToPage('Space Launch System', page, { x: 275, y: 480 });
-  rocketField.select('Saturn IV');
-
-  // Add the gundam check boxes, labels, and description
-  page.drawText('Select your favorite gundams:', { x: 50, y: 440, size: 20 });
-
-  page.drawText('Exia', { x: 120, y: 400, size: 18 });
-  page.drawText('Kyrios', { x: 120, y: 340, size: 18 });
-  page.drawText('Virtue', { x: 340, y: 400, size: 18 });
-  page.drawText('Dynames', { x: 340, y: 340, size: 18 });
-
-  const exiaField = form.createCheckBox('gundam.exia');
-  const kyriosField = form.createCheckBox('gundam.kyrios');
-  const virtueField = form.createCheckBox('gundam.virtue');
-  const dynamesField = form.createCheckBox('gundam.dynames');
-
-  exiaField.addToPage(page, { x: 55, y: 380 });
-  kyriosField.addToPage(page, { x: 55, y: 320 });
-  virtueField.addToPage(page, { x: 275, y: 380 });
-  dynamesField.addToPage(page, { x: 275, y: 320 });
-
-  exiaField.check();
-  dynamesField.check();
-
-  // Add the planet dropdown and description
-  page.drawText('Select your favorite planet*:', { x: 50, y: 280, size: 20 });
-
-  const planetsField = form.createDropdown('favorite.planet');
-  planetsField.addOptions(['Venus', 'Earth', 'Mars', 'Pluto']);
-  planetsField.select('Pluto');
-  planetsField.addToPage(page, { x: 55, y: 220 });
-
-  // Add the person option list and description
-  page.drawText('Select your favorite person:', { x: 50, y: 180, size: 18 });
-
-  const personField = form.createOptionList('favorite.person');
-  personField.addOptions([
-    'Julius Caesar',
-    'Ada Lovelace',
-    'Cleopatra',
-    'Aaron Burr',
-    'Mark Antony',
-  ]);
-  personField.select('Ada Lovelace');
-  personField.addToPage(page, { x: 55, y: 70 });
-
-  // Just saying...
-  page.drawText(`* Pluto should be a planet too!`, { x: 15, y: 15, size: 15 });
-
-  // Save the PDF with filled form fields
+  // Save the PDF
   const pdfBytes = await pdfDoc.save();
 
   fs.writeFileSync('out.pdf', pdfBytes);
-  openPdf('out.pdf', Reader.Preview);
+  openPdf('out.pdf', Reader.Acrobat);
 })();

--- a/src/api/PDFDocument.ts
+++ b/src/api/PDFDocument.ts
@@ -18,6 +18,7 @@ import {
   JpegEmbedder,
   PageBoundingBox,
   PageEmbeddingMismatchedContextError,
+  PDFBool,
   PDFCatalog,
   PDFContext,
   PDFDict,
@@ -43,6 +44,7 @@ import {
   LoadOptions,
   CreateOptions,
   EmbedFontOptions,
+  SetTitleOptions
 } from 'src/api/PDFDocumentOptions';
 import PDFObject from 'src/core/objects/PDFObject';
 import { Fontkit } from 'src/types/fontkit';
@@ -389,12 +391,24 @@ export default class PDFDocument {
    * ```js
    * pdfDoc.setTitle('🥚 The Life of an Egg 🍳')
    * ```
+   * To display the title in the window title of most PDF readers,
+   * set the `displayDocumentTitle` option to true. For example:
+   * ```js
+   * pdfDoc.setTitle('🥚 The Life of an Egg 🍳', { displayDocumentTitle: true })
+   * ```
    * @param title The title of this document.
+   * @param options The options to be used when setting the title.
    */
-  setTitle(title: string): void {
+  setTitle(title: string, options?: SetTitleOptions): void {
     assertIs(title, 'title', ['string']);
     const key = PDFName.of('Title');
     this.getInfoDict().set(key, PDFHexString.fromText(title));
+
+    if (options?.documentDisplayTitle) {
+      // Indicate that a reader should display
+      // the title as set rather than the filename.
+      this.catalog.ViewerPreferences().set(PDFName.of('DisplayDocTitle'), PDFBool.True)
+    }
   }
 
   /**

--- a/src/api/PDFDocument.ts
+++ b/src/api/PDFDocument.ts
@@ -44,7 +44,7 @@ import {
   LoadOptions,
   CreateOptions,
   EmbedFontOptions,
-  SetTitleOptions
+  SetTitleOptions,
 } from 'src/api/PDFDocumentOptions';
 import PDFObject from 'src/core/objects/PDFObject';
 import { Fontkit } from 'src/types/fontkit';
@@ -407,7 +407,9 @@ export default class PDFDocument {
     if (options?.documentDisplayTitle) {
       // Indicate that a reader should display
       // the title as set rather than the filename.
-      this.catalog.ViewerPreferences().set(PDFName.of('DisplayDocTitle'), PDFBool.True)
+      this.catalog
+        .ViewerPreferences()
+        .set(PDFName.of('DisplayDocTitle'), PDFBool.True);
     }
   }
 

--- a/src/api/PDFDocumentOptions.ts
+++ b/src/api/PDFDocumentOptions.ts
@@ -38,3 +38,7 @@ export interface EmbedFontOptions {
   customName?: string;
   features?: TypeFeatures;
 }
+
+export interface SetTitleOptions {
+  documentDisplayTitle: boolean
+}

--- a/src/api/PDFDocumentOptions.ts
+++ b/src/api/PDFDocumentOptions.ts
@@ -40,5 +40,5 @@ export interface EmbedFontOptions {
 }
 
 export interface SetTitleOptions {
-  documentDisplayTitle: boolean
+  documentDisplayTitle: boolean;
 }

--- a/src/core/structures/PDFCatalog.ts
+++ b/src/core/structures/PDFCatalog.ts
@@ -44,6 +44,21 @@ class PDFCatalog extends PDFDict {
   }
 
   /**
+   * See PDF 32000-1:2008 Section 12.2 for full ViewerPreferences specification.
+   */
+  ViewerPreferences(): PDFDict {
+    const viewerPrefs = this.lookupMaybe(PDFName.of('ViewerPreferences'), PDFDict);
+
+    if (viewerPrefs) {
+      return viewerPrefs
+    } else {
+      const newPrefs = PDFDict.withContext(this.context)
+      this.set(PDFName.of('ViewerPreferences'), newPrefs)
+      return newPrefs
+    }
+  }
+
+  /**
    * Inserts the given ref as a leaf node of this catalog's page tree at the
    * specified index (zero-based). Also increments the `Count` of each node in
    * the page tree hierarchy to accomodate the new page.

--- a/src/core/structures/PDFCatalog.ts
+++ b/src/core/structures/PDFCatalog.ts
@@ -47,14 +47,17 @@ class PDFCatalog extends PDFDict {
    * See PDF 32000-1:2008 Section 12.2 for full ViewerPreferences specification.
    */
   ViewerPreferences(): PDFDict {
-    const viewerPrefs = this.lookupMaybe(PDFName.of('ViewerPreferences'), PDFDict);
+    const viewerPrefs = this.lookupMaybe(
+      PDFName.of('ViewerPreferences'),
+      PDFDict,
+    );
 
     if (viewerPrefs) {
-      return viewerPrefs
+      return viewerPrefs;
     } else {
-      const newPrefs = PDFDict.withContext(this.context)
-      this.set(PDFName.of('ViewerPreferences'), newPrefs)
-      return newPrefs
+      const newPrefs = PDFDict.withContext(this.context);
+      this.set(PDFName.of('ViewerPreferences'), newPrefs);
+      return newPrefs;
     }
   }
 

--- a/tests/api/PDFDocument.spec.ts
+++ b/tests/api/PDFDocument.spec.ts
@@ -303,6 +303,36 @@ describe(`PDFDocument`, () => {
     });
   });
 
+  describe(`setTitle() method with options`, () => {
+    it(`defaults to an undefined ViewerPreferences dict`, async () => {
+      const pdfDoc = await PDFDocument.create();
+
+      expect(
+        pdfDoc.catalog.lookupMaybe(PDFName.of('ViewerPreferences'), PDFDict)
+      ).toBeUndefined();
+    });
+
+    it(`does not set the ViewerPreferences dict if the option is not set`, async () => {
+      const pdfDoc = await PDFDocument.create();
+
+      pdfDoc.setTitle('Testing setTitle Title')
+
+      expect(
+        pdfDoc.catalog.lookupMaybe(PDFName.of('ViewerPreferences'), PDFDict)
+      ).toBeUndefined();
+
+      expect(pdfDoc.getTitle()).toBe('Testing setTitle Title')
+    })
+
+    it(`creates the ViewerPreferences dict when the option is set`, async () => {
+      const pdfDoc = await PDFDocument.create();
+
+      pdfDoc.setTitle('ViewerPrefs Test Creation', { documentDisplayTitle: true })
+
+      expect(pdfDoc.catalog.lookupMaybe(PDFName.of('ViewerPreferences'), PDFDict));
+    })
+  });
+
   describe(`addJavaScript method`, () => {
     it(`adds the script to the catalog`, async () => {
       const pdfDoc = await PDFDocument.create();

--- a/tests/api/PDFDocument.spec.ts
+++ b/tests/api/PDFDocument.spec.ts
@@ -308,29 +308,33 @@ describe(`PDFDocument`, () => {
       const pdfDoc = await PDFDocument.create();
 
       expect(
-        pdfDoc.catalog.lookupMaybe(PDFName.of('ViewerPreferences'), PDFDict)
+        pdfDoc.catalog.lookupMaybe(PDFName.of('ViewerPreferences'), PDFDict),
       ).toBeUndefined();
     });
 
     it(`does not set the ViewerPreferences dict if the option is not set`, async () => {
       const pdfDoc = await PDFDocument.create();
 
-      pdfDoc.setTitle('Testing setTitle Title')
+      pdfDoc.setTitle('Testing setTitle Title');
 
       expect(
-        pdfDoc.catalog.lookupMaybe(PDFName.of('ViewerPreferences'), PDFDict)
+        pdfDoc.catalog.lookupMaybe(PDFName.of('ViewerPreferences'), PDFDict),
       ).toBeUndefined();
 
-      expect(pdfDoc.getTitle()).toBe('Testing setTitle Title')
-    })
+      expect(pdfDoc.getTitle()).toBe('Testing setTitle Title');
+    });
 
     it(`creates the ViewerPreferences dict when the option is set`, async () => {
       const pdfDoc = await PDFDocument.create();
 
-      pdfDoc.setTitle('ViewerPrefs Test Creation', { documentDisplayTitle: true })
+      pdfDoc.setTitle('ViewerPrefs Test Creation', {
+        documentDisplayTitle: true,
+      });
 
-      expect(pdfDoc.catalog.lookupMaybe(PDFName.of('ViewerPreferences'), PDFDict));
-    })
+      expect(
+        pdfDoc.catalog.lookupMaybe(PDFName.of('ViewerPreferences'), PDFDict),
+      );
+    });
   });
 
   describe(`addJavaScript method`, () => {


### PR DESCRIPTION
I added the `documentDisplayTitle` option on `PDFDocument.setTitle()`.

This option instructs PDF readers to display the specified document title in the title bar of the window displaying the document. This is a one of the requirements for passing accessibility checks.

The specification for this option can be found in PDF 32000-1:2008 Section 12.2.
The accessibility requirement can be found at Index 07-001 of the [Matterhorn Protocol checkpoint document](https://www.pdfa.org/resource/the-matterhorn-protocol-1-02/).

I've manually verified that this works in Acrobat, Firefox, and Chrome in OSX. 
It does not, however, seem to do anything in Preview in OSX. It seems that Preview always displays the filename in the window title. 🤷 

I've put some small tests around my changes in `setTitle`, but they mostly just verify that `ViewerPreferences` is working correctly. Since this is a feature that affects how readers behave, it's tough to test definitively. I'm open to suggestions on how to improve the tests around this.

Cheers!