### PR TITLE
Cleanup all annotations

### DIFF
--- a/apps/deno/tests/test18.ts
+++ b/apps/deno/tests/test18.ts
@@ -226,6 +226,12 @@ export default async (assets: Assets) => {
 
   form.getOptionList('List Box6').select('Honda');
 
+  const fieldToRemove = form.getRadioGroup('Group4');
+  form.removeField(fieldToRemove);
+  if (form.getFieldMaybe('Group4') !== undefined) {
+    throw new Error('Failed to remove field');
+  }
+
   form.flatten();
 
   // Copy pages from documents with flattened forms
@@ -236,6 +242,7 @@ export default async (assets: Assets) => {
     await loadD(assets),
     await loadE(assets),
   ];
+
   for (const formDoc of formDocs) {
     const [page1] = await pdfDoc.copyPages(formDoc, [0]);
     pdfDoc.addPage(page1);

--- a/apps/node/tests/test18.ts
+++ b/apps/node/tests/test18.ts
@@ -224,6 +224,12 @@ export default async (assets: Assets) => {
 
   form.getOptionList('List Box6').select('Honda');
 
+  const fieldToRemove = form.getRadioGroup('Group4');
+  form.removeField(fieldToRemove);
+  if (form.getFieldMaybe('Group4') !== undefined) {
+    throw new Error('Failed to remove field');
+  }
+
   form.flatten();
 
   // Copy pages from documents with flattened forms
@@ -234,6 +240,7 @@ export default async (assets: Assets) => {
     await loadD(assets),
     await loadE(assets),
   ];
+
   for (const formDoc of formDocs) {
     const [page1] = await pdfDoc.copyPages(formDoc, [0]);
     pdfDoc.addPage(page1);

--- a/apps/rn/src/tests/test18.js
+++ b/apps/rn/src/tests/test18.js
@@ -262,6 +262,12 @@ export default async () => {
 
   form.getOptionList('List Box6').select('Honda');
 
+  const fieldToRemove = form.getRadioGroup('Group4');
+  form.removeField(fieldToRemove);
+  if (form.getFieldMaybe('Group4') !== undefined) {
+    throw new Error('Failed to remove field');
+  }
+
   form.flatten();
 
   const assets = {
@@ -281,6 +287,7 @@ export default async () => {
     await loadD(assets),
     await loadE(assets),
   ];
+
   for (const formDoc of formDocs) {
     const [page1] = await pdfDoc.copyPages(formDoc, [0]);
     pdfDoc.addPage(page1);

--- a/apps/web/test18.html
+++ b/apps/web/test18.html
@@ -313,6 +313,12 @@
 
       form.getOptionList('List Box6').select('Honda');
 
+      const fieldToRemove = form.getRadioGroup('Group4');
+      form.removeField(fieldToRemove);
+      if (form.getFieldMaybe('Group4') !== undefined) {
+        throw new Error('Failed to remove field');
+      }
+
       form.flatten();
 
       const assets = {
@@ -332,6 +338,7 @@
         await loadD(assets),
         await loadE(assets),
       ];
+
       for (const formDoc of formDocs) {
         const [page1] = await pdfDoc.copyPages(formDoc, [0]);
         pdfDoc.addPage(page1);

--- a/scratchpad/index.ts
+++ b/scratchpad/index.ts
@@ -29,6 +29,12 @@ import { PDFDocument } from 'src/index';
 
   form.getOptionList('List Box6').select('Honda');
 
+  const fieldToRemove = form.getRadioGroup('Group4');
+  form.removeField(fieldToRemove);
+  if (form.getFieldMaybe('Group4') !== undefined) {
+    throw new Error('Failed to remove field');
+  }
+
   // Flatten the form's fields
   form.flatten();
 

--- a/src/api/form/PDFForm.ts
+++ b/src/api/form/PDFForm.ts
@@ -1,4 +1,5 @@
 import PDFDocument from 'src/api/PDFDocument';
+import PDFPage from 'src/api/PDFPage';
 import PDFField from 'src/api/form/PDFField';
 import PDFButton from 'src/api/form/PDFButton';
 import PDFCheckBox from 'src/api/form/PDFCheckBox';
@@ -38,6 +39,7 @@ import {
   PDFRef,
   createPDFAcroFields,
   PDFName,
+  PDFWidgetAnnotation,
 } from 'src/core';
 import { addRandomSuffix, assertIs, Cache, assertOrUndefined } from 'src/utils';
 
@@ -538,7 +540,6 @@ export default class PDFForm {
     }
 
     const fields = this.getFields();
-    const pages = this.doc.getPages();
 
     for (let i = 0, lenFields = fields.length; i < lenFields; i++) {
       const field = fields[i];
@@ -546,42 +547,11 @@ export default class PDFForm {
 
       for (let j = 0, lenWidgets = widgets.length; j < lenWidgets; j++) {
         const widget = widgets[j];
-        const pageRef = widget.P();
-        let page = pages.find((x) => x.ref === pageRef);
-        if (page === undefined) {
-          const widgetRef = this.doc.context.getObjectRef(widget.dict);
-          if (widgetRef === undefined) {
-            throw new Error('Could not find PDFRef for PDFObject');
-          }
-
-          page = this.doc.findPageForAnnotationRef(widgetRef);
-
-          if (page === undefined) {
-            throw new Error(`Could not find page for PDFRef ${widgetRef}`);
-          }
-        }
-
-        let refOrDict = widget.getNormalAppearance();
-
-        if (
-          refOrDict instanceof PDFDict &&
-          (field instanceof PDFCheckBox || field instanceof PDFRadioGroup)
-        ) {
-          const value = field.acroField.getValue();
-          const ref = refOrDict.get(value) ?? refOrDict.get(PDFName.of('Off'));
-
-          if (ref instanceof PDFRef) {
-            refOrDict = ref;
-          }
-        }
-
-        if (!(refOrDict instanceof PDFRef)) {
-          const name = field.getName();
-          throw new Error(`Failed to extract appearance ref for: ${name}`);
-        }
+        const page = this.findWidgetPage(widget);
+        const widgetRef = this.findWidgetAppearanceRef(field, widget);
 
         const xObjectKey = addRandomSuffix('FlatWidget', 10);
-        page.node.setXObject(PDFName.of(xObjectKey), refOrDict);
+        page.node.setXObject(PDFName.of(xObjectKey), widgetRef);
 
         const rectangle = widget.getRectangle();
 
@@ -594,7 +564,6 @@ export default class PDFForm {
         ].filter(Boolean) as PDFOperator[];
 
         page.pushOperators(...operators);
-        page.node.removeAnnot(refOrDict);
       }
 
       this.removeField(field);
@@ -612,6 +581,20 @@ export default class PDFForm {
    * ```
    */
   removeField(field: PDFField) {
+    const widgets = field.acroField.getWidgets();
+    const pages: Set<PDFPage> = new Set();
+
+    for (let i = 0, len = widgets.length; i < len; i++) {
+      const widget = widgets[i];
+      const widgetRef = this.findWidgetAppearanceRef(field, widget);
+
+      const page = this.findWidgetPage(widget);
+      pages.add(page);
+
+      page.node.removeAnnot(widgetRef);
+    }
+
+    pages.forEach((page) => page.node.removeAnnot(field.ref));
     this.acroForm.removeField(field.acroField);
     this.doc.context.delete(field.ref);
   }
@@ -707,6 +690,51 @@ export default class PDFForm {
 
   getDefaultFont() {
     return this.defaultFontCache.access();
+  }
+
+  private findWidgetPage(widget: PDFWidgetAnnotation): PDFPage {
+    const pageRef = widget.P();
+    let page = this.doc.getPages().find((x) => x.ref === pageRef);
+    if (page === undefined) {
+      const widgetRef = this.doc.context.getObjectRef(widget.dict);
+      if (widgetRef === undefined) {
+        throw new Error('Could not find PDFRef for PDFObject');
+      }
+
+      page = this.doc.findPageForAnnotationRef(widgetRef);
+
+      if (page === undefined) {
+        throw new Error(`Could not find page for PDFRef ${widgetRef}`);
+      }
+    }
+
+    return page;
+  }
+
+  private findWidgetAppearanceRef(
+    field: PDFField,
+    widget: PDFWidgetAnnotation,
+  ): PDFRef {
+    let refOrDict = widget.getNormalAppearance();
+
+    if (
+      refOrDict instanceof PDFDict &&
+      (field instanceof PDFCheckBox || field instanceof PDFRadioGroup)
+    ) {
+      const value = field.acroField.getValue();
+      const ref = refOrDict.get(value) ?? refOrDict.get(PDFName.of('Off'));
+
+      if (ref instanceof PDFRef) {
+        refOrDict = ref;
+      }
+    }
+
+    if (!(refOrDict instanceof PDFRef)) {
+      const name = field.getName();
+      throw new Error(`Failed to extract appearance ref for: ${name}`);
+    }
+
+    return refOrDict;
   }
 
   private findOrCreateNonTerminals(partialNames: string[]) {


### PR DESCRIPTION
Most viewers, including `PDF.js` and `Preview` do not seem to mind the annotations but it was preventing `Adobe Acrobat` printing a flattened document:

![](https://cdn.discordapp.com/attachments/776132863992266763/798667554565914664/unknown.png)
