### PR TITLE
switch PDFPageEmbedder from contex.stream to .flateStream to compress page

### DIFF
--- a/src/core/embedders/PDFPageEmbedder.ts
+++ b/src/core/embedders/PDFPageEmbedder.ts
@@ -96,7 +96,7 @@ class PDFPageEmbedder {
     const decodedContents = this.decodeContents(Contents);
 
     const { left, bottom, right, top } = this.boundingBox;
-    const xObject = context.stream(decodedContents, {
+    const xObject = context.flateStream(decodedContents, {
       Type: 'XObject',
       Subtype: 'Form',
       FormType: 1,


### PR DESCRIPTION
I was curious about #639 and spent some time digging into `pdf-lib` and came up with a solution. I realize I'm changing the default from a regular stream to a compressed stream for the embedded PDF page but after some reflection, it seemed like this would be what most/all would want anyway?

Resolves #639