### PR TITLE
Allow custom image key

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "DkDavid (https://github.com/DkDavid)",
     "Bj Tecu (https://github.com/btecu)",
     "Brent McSharry (https://github.com/mcshaz)",
-    "Tim Knapp (https://github.com/duffyd)"
+    "Tim Knapp (https://github.com/duffyd)",
+    "Ching Chang (https://github.com/ChingChang9)"
   ],
   "scripts": {
     "release:latest": "yarn publish --tag latest && yarn pack && yarn release:tag",

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -972,8 +972,11 @@ export default class PDFPage {
     assertOrUndefined(options.ySkew, 'options.ySkew', [[Object, 'Rotation']]);
     assertRangeOrUndefined(options.opacity, 'opacity.opacity', 0, 1);
     assertIsOneOfOrUndefined(options.blendMode, 'options.blendMode', BlendMode);
+    assertOrUndefined(options.imageKey, 'options.imageKey', ['string']);
 
-    const xObjectKey = addRandomSuffix('Image', 10);
+    const xObjectKey = options.imageKey
+      ? `Image-${options.imageKey}`
+      : addRandomSuffix('Image', 10);
     this.node.setXObject(PDFName.of(xObjectKey), image.ref);
 
     const graphicsStateKey = this.maybeEmbedGraphicsState({

--- a/src/api/PDFPageOptions.ts
+++ b/src/api/PDFPageOptions.ts
@@ -44,6 +44,7 @@ export interface PDFPageDrawImageOptions {
   ySkew?: Rotation;
   opacity?: number;
   blendMode?: BlendMode;
+  imageKey?: string;
 }
 
 export interface PDFPageDrawPageOptions {

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -114,6 +114,7 @@ export const drawImage = (
     xSkew: Rotation;
     ySkew: Rotation;
     graphicsState?: string | PDFName;
+    imageKey?: string;
   },
 ): PDFOperator[] =>
   [
@@ -443,19 +444,19 @@ export const rotateInPlace = (options: {
   rotation: 0 | 90 | 180 | 270;
 }) =>
     options.rotation === 0 ? [
-      translate(0, 0), 
-      rotateDegrees(0) 
+      translate(0, 0),
+      rotateDegrees(0)
     ]
   : options.rotation === 90 ? [
-      translate(options.width, 0), 
+      translate(options.width, 0),
       rotateDegrees(90)
     ]
   : options.rotation === 180 ? [
-      translate(options.width, options.height), 
+      translate(options.width, options.height),
       rotateDegrees(180)
     ]
   : options.rotation === 270 ? [
-      translate(0, options.height), 
+      translate(0, options.height),
       rotateDegrees(270)
     ]
   : []; // Invalid rotation - noop

--- a/tests/api/PDFDocument.spec.ts
+++ b/tests/api/PDFDocument.spec.ts
@@ -172,6 +172,49 @@ describe(`PDFDocument`, () => {
     });
   });
 
+  describe(`drawImage() method`, () => {
+    it(`serializes the same value on every save when using a custom image key`, async () => {
+      const imageBuffer = fs.readFileSync('assets/images/mario_emblem.png');
+      const imageKey = 'uniqueImageKey';
+      const pdfDoc1 = await PDFDocument.create({ updateMetadata: false });
+      const pdfDoc2 = await PDFDocument.create({ updateMetadata: false });
+
+      const imageEmbed1 = await pdfDoc1.embedPng(imageBuffer);
+      const imageEmbed2 = await pdfDoc2.embedPng(imageBuffer);
+
+      const page1 = pdfDoc1.addPage([imageEmbed1.width, imageEmbed1.height]);
+      const page2 = pdfDoc2.addPage([imageEmbed2.width, imageEmbed2.height]);
+
+      page1.drawImage(imageEmbed1, { imageKey });
+      page2.drawImage(imageEmbed2, { imageKey });
+
+      const savedDoc1 = await pdfDoc1.save();
+      const savedDoc2 = await pdfDoc2.save();
+
+      expect(savedDoc1).toEqual(savedDoc2);
+    });
+
+    it(`does not serialize the same on save when not using a custom image key`, async () => {
+      const imageBuffer = fs.readFileSync('assets/images/mario_emblem.png');
+      const pdfDoc1 = await PDFDocument.create();
+      const pdfDoc2 = await PDFDocument.create();
+
+      const imageEmbed1 = await pdfDoc1.embedPng(imageBuffer);
+      const imageEmbed2 = await pdfDoc2.embedPng(imageBuffer);
+
+      const page1 = pdfDoc1.addPage([imageEmbed1.width, imageEmbed1.height]);
+      const page2 = pdfDoc2.addPage([imageEmbed2.width, imageEmbed2.height]);
+
+      page1.drawImage(imageEmbed1);
+      page2.drawImage(imageEmbed2);
+
+      const savedDoc1 = await pdfDoc1.save();
+      const savedDoc2 = await pdfDoc2.save();
+
+      expect(savedDoc1).not.toEqual(savedDoc2);
+    });
+  });
+
   describe(`setLanguage() method`, () => {
     it(`sets the language of the document`, async () => {
       const pdfDoc = await PDFDocument.create();


### PR DESCRIPTION
Fixes #923 by adding an optional parameter to `PDFPageDrawImageOptions`

I've ran integration tests in addition to unit tests. They all passed. However, I did not write a test to check whether the custom image key is properly written into the `pool` variable in `PDFName`, since I wasn't able to figure out how to check whether a certain key is in `pool` (calling `Name.of` if the key doesn't exist would just set it on the spot and return it). Looking at [the line where `PDFName.of` is called](https://github.com/Hopding/pdf-lib/blob/d213f921237daca7a5e21fb38eb69d733ff34796/src/api/PDFPage.ts#L977), and the `PDFName.of` method, I think the abscence of this test should be okay(?). If otherwise, I'd need some help