### PR TITLE
Scale page content

### DIFF
--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -40,6 +40,7 @@ import {
   PDFOperator,
   PDFPageLeaf,
   PDFRef,
+  PDFNumber
 } from 'src/core';
 import {
   addRandomSuffix,
@@ -586,6 +587,269 @@ export default class PDFPage {
     const endRef = this.doc.context.register(end);
 
     this.node.wrapContentStreams(startRef, endRef);
+  }
+
+  /**
+   * 
+   * @param x The factor by wich the x-axis for the annots should be scaled (e.g. 0.5 is 50%)
+   * @param y The factor by wich the y-axis for the annots should be scaled (e.g. 0.5 is 50%)
+   */
+  scaleAnnots(x: number, y: number) {
+    const annots = this.node.Annots();
+
+    // loop annotations
+    annots?.asArray().forEach((ref: any) => {
+      //@ts-ignore
+      const annot = annots.context.lookup(ref);
+
+      /**
+       * PDFName { encodedName: '/Caret' }
+       * PDFName { encodedName: '/Circle' }
+       * PDFName { encodedName: '/FreeText' }
+       * PDFName { encodedName: '/Square' }
+       */
+      //@ts-ignore
+      const pdfNameRD = annot.dict.get(PDFName.of('RD'));
+      if (pdfNameRD) {
+        //@ts-ignore
+        pdfNameRD.set(0, new PDFNumber(pdfNameRD.get(0).numberValue * x));
+        //@ts-ignore
+        pdfNameRD.set(1, new PDFNumber(pdfNameRD.get(1).numberValue * y));
+        //@ts-ignore
+        pdfNameRD.set(2, new PDFNumber(pdfNameRD.get(2).numberValue * x));
+        //@ts-ignore
+        pdfNameRD.set(3, new PDFNumber(pdfNameRD.get(3).numberValue * y));
+      }
+
+      /**
+       * PDFName { encodedName: '/FreeText' }
+       */
+      //@ts-ignore
+      const pdfNameCL = annot.dict.get(PDFName.of('CL'));
+      if (pdfNameCL) {
+        //@ts-ignore
+        pdfNameCL.set(0, new PDFNumber(pdfNameCL.get(0).numberValue * x));
+        //@ts-ignore
+        pdfNameCL.set(1, new PDFNumber(pdfNameCL.get(1).numberValue * y));
+        //@ts-ignore
+        pdfNameCL.set(2, new PDFNumber(pdfNameCL.get(2).numberValue * x));
+        //@ts-ignore
+        pdfNameCL.set(3, new PDFNumber(pdfNameCL.get(3).numberValue * y));
+        //@ts-ignore
+        pdfNameCL.set(4, new PDFNumber(pdfNameCL.get(4).numberValue * x));
+        //@ts-ignore
+        pdfNameCL.set(5, new PDFNumber(pdfNameCL.get(5).numberValue * y));
+      }
+
+      /**
+       * PDFName { encodedName: '/Ink' }
+       */
+      //@ts-ignore
+      const pdfNameInkList = annot.dict.get(PDFName.of('InkList'));
+      if (pdfNameInkList) {
+        const length =
+          pdfNameInkList?.array && pdfNameInkList?.array[0]?.array?.length;
+        if (length) {
+          // can there be more then 1? I might need to loop them ?
+          const internalArray = pdfNameInkList?.array[0];
+          for (let v = 0; v < length; v++) {
+            if (v % 2 === 0 || v % 2 === undefined) {
+              internalArray.set(
+                v,
+                //@ts-ignore
+                new PDFNumber(internalArray.get(v).numberValue * x)
+              );
+            } else {
+              internalArray.set(
+                v,
+                //@ts-ignore
+                new PDFNumber(internalArray.get(v).numberValue * y)
+              );
+            }
+          }
+        }
+      }
+
+      /**
+       * PDFName { encodedName: '/Polygon' }
+       * PDFName { encodedName: '/PolyLine' }
+       */
+      //@ts-ignore
+      const pdfNameVertices = annot.dict.get(PDFName.of('Vertices'));
+      if (pdfNameVertices) {
+        const length = pdfNameVertices?.array?.length;
+        if (length) {
+          for (let v = 0; v < length; v++) {
+            if (v % 2 === 0 || v % 2 === undefined) {
+              pdfNameVertices.set(
+                v,
+                //@ts-ignore
+                new PDFNumber(pdfNameVertices.get(v).numberValue * x)
+              );
+            } else {
+              pdfNameVertices.set(
+                v,
+                //@ts-ignore
+                new PDFNumber(pdfNameVertices.get(v).numberValue * y)
+              );
+            }
+          }
+        }
+      }
+
+      /**
+       * PDFName { encodedName: '/Highlight' }
+       * PDFName { encodedName: '/StrikeOut' }
+       * PDFName { encodedName: '/Underline' }
+       */
+      //@ts-ignore
+      const pdfNameQuadPoints = annot.dict.get(PDFName.of('QuadPoints'));
+      if (pdfNameQuadPoints) {
+        const length = pdfNameQuadPoints?.array?.length;
+        if (length) {
+          for (let v = 0; v < length; v++) {
+            if (v % 2 === 0 || v % 2 === undefined) {
+              pdfNameQuadPoints.set(
+                v,
+                //@ts-ignore
+                new PDFNumber(pdfNameQuadPoints.get(v).numberValue * x)
+              );
+            } else {
+              //@ts-ignore
+              pdfNameQuadPoints.set(
+                v,
+                //@ts-ignore
+                new PDFNumber(pdfNameQuadPoints.get(v).numberValue * y)
+              );
+            }
+          }
+        }
+      }
+
+      /**
+       * PDFName { encodedName: '/Line' }
+       */
+      //@ts-ignore
+      const pdfNameL = annot.dict.get(PDFName.of('L'));
+      if (pdfNameL) {
+        //@ts-ignore
+        pdfNameL.set(0, new PDFNumber(pdfNameL.get(0).numberValue * x));
+        //@ts-ignore
+        pdfNameL.set(1, new PDFNumber(pdfNameL.get(1).numberValue * y));
+        //@ts-ignore
+        pdfNameL.set(2, new PDFNumber(pdfNameL.get(2).numberValue * x));
+        //@ts-ignore
+        pdfNameL.set(3, new PDFNumber(pdfNameL.get(3).numberValue * y));
+      }
+
+      /**
+       * all...
+       */
+      //@ts-ignore
+      const pdfNameRect = annot.dict.get(PDFName.of('Rect'));
+      if (pdfNameRect) {
+        //@ts-ignore
+        pdfNameRect.set(0, new PDFNumber(pdfNameRect.get(0).numberValue * x));
+        //@ts-ignore
+        pdfNameRect.set(1, new PDFNumber(pdfNameRect.get(1).numberValue * y));
+        //@ts-ignore
+        pdfNameRect.set(2, new PDFNumber(pdfNameRect.get(2).numberValue * x));
+        //@ts-ignore
+        pdfNameRect.set(3, new PDFNumber(pdfNameRect.get(3).numberValue * y));
+      }
+
+      /**
+       * PDFName { encodedName: '/Caret' }
+       * PDFName { encodedName: '/FreeText' }
+       * PDFName { encodedName: '/Text' }
+       * TODO: put in function and add tests...
+       */
+      //@ts-ignore
+      const pdfNameRCfontsize = annot.dict.get(PDFName.of('RC'));
+      if (pdfNameRCfontsize) {
+        const beforeandafter = encodeURI(pdfNameRCfontsize.value).split(
+          /font-size:[0-9]*?.?[0-9]*?pt/
+        );
+
+        const matches = pdfNameRCfontsize.value.match(
+          /font-size:[0-9]*?.?[0-9]*?pt/g
+        );
+
+        if (matches?.length) {
+          const fontsizes: string[] = [];
+
+          matches.forEach((r: string) => {
+            const fontmatches = r.split(/[0-9]*.[0-9]/);
+
+            let value = r;
+
+            fontmatches.forEach((x) => {
+              value = value.replace(x, '');
+            });
+            // @ts-ignore
+
+            value = value.replace(':', '');
+
+            const fontsize = ((value as any) * (1 * x)).toFixed(1);
+
+            fontsizes.push(`${fontmatches[0]}:${fontsize}${fontmatches[2]}`);
+          });
+
+          pdfNameRCfontsize.value = '';
+
+          beforeandafter.forEach((x) => {
+            pdfNameRCfontsize.value =
+              pdfNameRCfontsize.value +
+              decodeURI(`${x}${fontsizes.length ? fontsizes.shift() : ''}`);
+          });
+        }
+      }
+
+      /**
+       * PDFName { encodedName: '/Caret' }
+       * PDFName { encodedName: '/FreeText' }
+       * PDFName { encodedName: '/Text' }
+       * TODO: put in function and add tests...
+       */
+      //@ts-ignore
+      const pdfNameRCLineheight = annot.dict.get(PDFName.of('RC'));
+      if (pdfNameRCLineheight) {
+        const beforeandafter = encodeURI(pdfNameRCLineheight.value).split(
+          /line-height:[0-9]*?.?[0-9]*?pt/
+        );
+
+        const matches = pdfNameRCLineheight.value.match(
+          /line-height:[0-9]*?.?[0-9]*?pt/g
+        );
+
+        if (matches?.length) {
+          const fontsizes: string[] = [];
+
+          matches.forEach((r: string) => {
+            const fontmatches = r.split(/[0-9]*.[0-9]/);
+
+            let value = r;
+
+            fontmatches.forEach((x) => {
+              value = value.replace(x, '');
+            });
+
+            value = value.replace(':', '');
+
+            const fontsize = ((value as any) * (1 * x)).toFixed(1);
+            fontsizes.push(`${fontmatches[0]}:${fontsize}${fontmatches[2]}`);
+          });
+
+          pdfNameRCLineheight.value = '';
+
+          beforeandafter.forEach((x) => {
+            pdfNameRCLineheight.value =
+              pdfNameRCLineheight.value +
+              decodeURI(`${x}${fontsizes.length ? fontsizes.shift() : ''}`);
+          });
+        }
+      }
+    });
   }
 
   /**

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -13,6 +13,7 @@ import {
   pushGraphicsState,
   translate,
   LineCapStyle,
+  scale,
 } from 'src/api/operators';
 import PDFDocument from 'src/api/PDFDocument';
 import PDFEmbeddedPage from 'src/api/PDFEmbeddedPage';
@@ -558,6 +559,27 @@ export default class PDFPage {
       pushGraphicsState(),
       translate(x, y),
     );
+    const startRef = this.doc.context.register(start);
+
+    const end = this.createContentStream(popGraphicsState());
+    const endRef = this.doc.context.register(end);
+
+    this.node.wrapContentStreams(startRef, endRef);
+  }
+
+  /**
+   * 
+   * @param x The factor by wich the x-axis for the content should be scaled (e.g. 0.5 is 50%)
+   * @param y The factor by wich the y-axis for the content should be scaled (e.g. 0.5 is 50%)
+   */
+  scaleContent(x: number, y: number): void {
+    assertIs(x, 'x', ['number']);
+    assertIs(y, 'y', ['number']);
+
+    this.node.normalize();
+    this.getContentStream();
+
+    const start = this.createContentStream(pushGraphicsState(), scale(x, y));
     const startRef = this.doc.context.register(start);
 
     const end = this.createContentStream(popGraphicsState());

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -40,7 +40,10 @@ import {
   PDFOperator,
   PDFPageLeaf,
   PDFRef,
-  PDFNumber
+  PDFNumber,
+  PDFDict,
+  PDFArray,
+  PDFObject,
 } from 'src/core';
 import {
   addRandomSuffix,
@@ -569,7 +572,15 @@ export default class PDFPage {
   }
 
   /**
+   * Scale the content of a page. This is useful after resizing an exisiting page.
+   * This scales only the content not the annots. See also: [[scaleAnnots]]
+   * ```js
+   * // bisect the size of the page
+   * p.setSize(p.getWidth() / 2, p.getHeight() / 2);
    * 
+   * // scale the content of the page down by 50% in x and y
+   * page.scaleContent(0.5, 0.5);
+   * ```
    * @param x The factor by wich the x-axis for the content should be scaled (e.g. 0.5 is 50%)
    * @param y The factor by wich the y-axis for the content should be scaled (e.g. 0.5 is 50%)
    */
@@ -590,7 +601,15 @@ export default class PDFPage {
   }
 
   /**
+   * Scale the annots of a page. This is useful if you want to scale a page with comments or other annots.
+   * ```JS
+   * // scale the content of the page down by 50% in x and y
+   * page.scaleContent(0.5, 0.5);
    * 
+   * // scale the content of the page down by 50% in x and y
+   * page.scaleAnnots(0.5, 0.5);
+   * ```
+   * See alos: [[scaleContent]]
    * @param x The factor by wich the x-axis for the annots should be scaled (e.g. 0.5 is 50%)
    * @param y The factor by wich the y-axis for the annots should be scaled (e.g. 0.5 is 50%)
    */
@@ -598,257 +617,23 @@ export default class PDFPage {
     const annots = this.node.Annots();
 
     // loop annotations
-    annots?.asArray().forEach((ref: any) => {
-      //@ts-ignore
-      const annot = annots.context.lookup(ref);
+    annots?.asArray().forEach((ref: PDFObject) => {
 
-      /**
-       * PDFName { encodedName: '/Caret' }
-       * PDFName { encodedName: '/Circle' }
-       * PDFName { encodedName: '/FreeText' }
-       * PDFName { encodedName: '/Square' }
-       */
-      //@ts-ignore
-      const pdfNameRD = annot.dict.get(PDFName.of('RD'));
-      if (pdfNameRD) {
-        //@ts-ignore
-        pdfNameRD.set(0, new PDFNumber(pdfNameRD.get(0).numberValue * x));
-        //@ts-ignore
-        pdfNameRD.set(1, new PDFNumber(pdfNameRD.get(1).numberValue * y));
-        //@ts-ignore
-        pdfNameRD.set(2, new PDFNumber(pdfNameRD.get(2).numberValue * x));
-        //@ts-ignore
-        pdfNameRD.set(3, new PDFNumber(pdfNameRD.get(3).numberValue * y));
-      }
+      const i = annots.indexOf(ref);
 
-      /**
-       * PDFName { encodedName: '/FreeText' }
-       */
-      //@ts-ignore
-      const pdfNameCL = annot.dict.get(PDFName.of('CL'));
-      if (pdfNameCL) {
-        //@ts-ignore
-        pdfNameCL.set(0, new PDFNumber(pdfNameCL.get(0).numberValue * x));
-        //@ts-ignore
-        pdfNameCL.set(1, new PDFNumber(pdfNameCL.get(1).numberValue * y));
-        //@ts-ignore
-        pdfNameCL.set(2, new PDFNumber(pdfNameCL.get(2).numberValue * x));
-        //@ts-ignore
-        pdfNameCL.set(3, new PDFNumber(pdfNameCL.get(3).numberValue * y));
-        //@ts-ignore
-        pdfNameCL.set(4, new PDFNumber(pdfNameCL.get(4).numberValue * x));
-        //@ts-ignore
-        pdfNameCL.set(5, new PDFNumber(pdfNameCL.get(5).numberValue * y));
-      }
+      if (i === undefined) return;
 
-      /**
-       * PDFName { encodedName: '/Ink' }
-       */
-      //@ts-ignore
-      const pdfNameInkList = annot.dict.get(PDFName.of('InkList'));
-      if (pdfNameInkList) {
-        const length =
-          pdfNameInkList?.array && pdfNameInkList?.array[0]?.array?.length;
-        if (length) {
-          // can there be more then 1? I might need to loop them ?
-          const internalArray = pdfNameInkList?.array[0];
-          for (let v = 0; v < length; v++) {
-            if (v % 2 === 0 || v % 2 === undefined) {
-              internalArray.set(
-                v,
-                //@ts-ignore
-                new PDFNumber(internalArray.get(v).numberValue * x)
-              );
-            } else {
-              internalArray.set(
-                v,
-                //@ts-ignore
-                new PDFNumber(internalArray.get(v).numberValue * y)
-              );
-            }
-          }
-        }
-      }
+      const annot = annots.lookup(i, PDFDict);
 
-      /**
-       * PDFName { encodedName: '/Polygon' }
-       * PDFName { encodedName: '/PolyLine' }
-       */
-      //@ts-ignore
-      const pdfNameVertices = annot.dict.get(PDFName.of('Vertices'));
-      if (pdfNameVertices) {
-        const length = pdfNameVertices?.array?.length;
-        if (length) {
-          for (let v = 0; v < length; v++) {
-            if (v % 2 === 0 || v % 2 === undefined) {
-              pdfNameVertices.set(
-                v,
-                //@ts-ignore
-                new PDFNumber(pdfNameVertices.get(v).numberValue * x)
-              );
-            } else {
-              pdfNameVertices.set(
-                v,
-                //@ts-ignore
-                new PDFNumber(pdfNameVertices.get(v).numberValue * y)
-              );
-            }
-          }
-        }
-      }
+      if (!annot) return;
 
-      /**
-       * PDFName { encodedName: '/Highlight' }
-       * PDFName { encodedName: '/StrikeOut' }
-       * PDFName { encodedName: '/Underline' }
-       */
-      //@ts-ignore
-      const pdfNameQuadPoints = annot.dict.get(PDFName.of('QuadPoints'));
-      if (pdfNameQuadPoints) {
-        const length = pdfNameQuadPoints?.array?.length;
-        if (length) {
-          for (let v = 0; v < length; v++) {
-            if (v % 2 === 0 || v % 2 === undefined) {
-              pdfNameQuadPoints.set(
-                v,
-                //@ts-ignore
-                new PDFNumber(pdfNameQuadPoints.get(v).numberValue * x)
-              );
-            } else {
-              //@ts-ignore
-              pdfNameQuadPoints.set(
-                v,
-                //@ts-ignore
-                new PDFNumber(pdfNameQuadPoints.get(v).numberValue * y)
-              );
-            }
-          }
-        }
-      }
+      ['RD', 'CL', 'Vertices', 'QuadPoints', 'L', 'Rect'].forEach((el) => {
+        const list = annot.get(PDFName.of(el)) as PDFArray;
+        if (list) this.scalePDFNumbers(list, x, y);
+      });
 
-      /**
-       * PDFName { encodedName: '/Line' }
-       */
-      //@ts-ignore
-      const pdfNameL = annot.dict.get(PDFName.of('L'));
-      if (pdfNameL) {
-        //@ts-ignore
-        pdfNameL.set(0, new PDFNumber(pdfNameL.get(0).numberValue * x));
-        //@ts-ignore
-        pdfNameL.set(1, new PDFNumber(pdfNameL.get(1).numberValue * y));
-        //@ts-ignore
-        pdfNameL.set(2, new PDFNumber(pdfNameL.get(2).numberValue * x));
-        //@ts-ignore
-        pdfNameL.set(3, new PDFNumber(pdfNameL.get(3).numberValue * y));
-      }
-
-      /**
-       * all...
-       */
-      //@ts-ignore
-      const pdfNameRect = annot.dict.get(PDFName.of('Rect'));
-      if (pdfNameRect) {
-        //@ts-ignore
-        pdfNameRect.set(0, new PDFNumber(pdfNameRect.get(0).numberValue * x));
-        //@ts-ignore
-        pdfNameRect.set(1, new PDFNumber(pdfNameRect.get(1).numberValue * y));
-        //@ts-ignore
-        pdfNameRect.set(2, new PDFNumber(pdfNameRect.get(2).numberValue * x));
-        //@ts-ignore
-        pdfNameRect.set(3, new PDFNumber(pdfNameRect.get(3).numberValue * y));
-      }
-
-      /**
-       * PDFName { encodedName: '/Caret' }
-       * PDFName { encodedName: '/FreeText' }
-       * PDFName { encodedName: '/Text' }
-       * TODO: put in function and add tests...
-       */
-      //@ts-ignore
-      const pdfNameRCfontsize = annot.dict.get(PDFName.of('RC'));
-      if (pdfNameRCfontsize) {
-        const beforeandafter = encodeURI(pdfNameRCfontsize.value).split(
-          /font-size:[0-9]*?.?[0-9]*?pt/
-        );
-
-        const matches = pdfNameRCfontsize.value.match(
-          /font-size:[0-9]*?.?[0-9]*?pt/g
-        );
-
-        if (matches?.length) {
-          const fontsizes: string[] = [];
-
-          matches.forEach((r: string) => {
-            const fontmatches = r.split(/[0-9]*.[0-9]/);
-
-            let value = r;
-
-            fontmatches.forEach((x) => {
-              value = value.replace(x, '');
-            });
-            // @ts-ignore
-
-            value = value.replace(':', '');
-
-            const fontsize = ((value as any) * (1 * x)).toFixed(1);
-
-            fontsizes.push(`${fontmatches[0]}:${fontsize}${fontmatches[2]}`);
-          });
-
-          pdfNameRCfontsize.value = '';
-
-          beforeandafter.forEach((x) => {
-            pdfNameRCfontsize.value =
-              pdfNameRCfontsize.value +
-              decodeURI(`${x}${fontsizes.length ? fontsizes.shift() : ''}`);
-          });
-        }
-      }
-
-      /**
-       * PDFName { encodedName: '/Caret' }
-       * PDFName { encodedName: '/FreeText' }
-       * PDFName { encodedName: '/Text' }
-       * TODO: put in function and add tests...
-       */
-      //@ts-ignore
-      const pdfNameRCLineheight = annot.dict.get(PDFName.of('RC'));
-      if (pdfNameRCLineheight) {
-        const beforeandafter = encodeURI(pdfNameRCLineheight.value).split(
-          /line-height:[0-9]*?.?[0-9]*?pt/
-        );
-
-        const matches = pdfNameRCLineheight.value.match(
-          /line-height:[0-9]*?.?[0-9]*?pt/g
-        );
-
-        if (matches?.length) {
-          const fontsizes: string[] = [];
-
-          matches.forEach((r: string) => {
-            const fontmatches = r.split(/[0-9]*.[0-9]/);
-
-            let value = r;
-
-            fontmatches.forEach((x) => {
-              value = value.replace(x, '');
-            });
-
-            value = value.replace(':', '');
-
-            const fontsize = ((value as any) * (1 * x)).toFixed(1);
-            fontsizes.push(`${fontmatches[0]}:${fontsize}${fontmatches[2]}`);
-          });
-
-          pdfNameRCLineheight.value = '';
-
-          beforeandafter.forEach((x) => {
-            pdfNameRCLineheight.value =
-              pdfNameRCLineheight.value +
-              decodeURI(`${x}${fontsizes.length ? fontsizes.shift() : ''}`);
-          });
-        }
-      }
+      const pdfNameInkList = annot.get(PDFName.of('InkList')) as PDFArray;
+      pdfNameInkList?.asArray().forEach((arr) => this.scalePDFNumbers(arr as PDFArray, x, y));
     });
   }
 
@@ -1785,5 +1570,14 @@ export default class PDFPage {
     this.node.setExtGState(PDFName.of(key), graphicsState);
 
     return key;
+  }
+
+  private scalePDFNumbers(arr: PDFArray, x: number, y: number): void {
+    arr?.asArray().forEach((el, i) => {
+      if (el instanceof PDFNumber) {
+        const factor = i % 2 === 0 ? x : y;
+        arr.set(i, PDFNumber.of(el.asNumber() * factor));
+      }
+    });
   }
 }


### PR DESCRIPTION
I added two functions to the PDFPage to scale the content and the annots. This enables to resize the content and annots without violating private access modifiers. The code is inspired by the [Resizer Example](https://github.com/vegarringdal/simple-pdf-resizer).