### PR TITLE
Find and remove child widgets from the document context

### DIFF
--- a/src/api/form/PDFForm.ts
+++ b/src/api/form/PDFForm.ts
@@ -596,6 +596,15 @@ export default class PDFForm {
 
     pages.forEach((page) => page.node.removeAnnot(field.ref));
     this.acroForm.removeField(field.acroField);
+    const docHandle = this.doc;
+    field.acroField
+      .normalizedEntries()
+      .Kids.asArray()
+      .forEach((child) => {
+        if (child instanceof PDFRef) {
+          docHandle.context.delete(child);
+        }
+      });
     this.doc.context.delete(field.ref);
   }
 


### PR DESCRIPTION
Fixes #1001 

When removing a field from the document, we need to remove the children of the field first; otherwise, some renderers will still see the remnants and display these dangling widgets.


## What?

Finds and removes child widgets of a field and removes them from the document context before removing field itself.

## Why?

Stops some renderers from still finding the dangling widgets and rendering their default appearances

## How?

In the removeField function, right before removing the field reference from the document context, we look for the field children by getting it's normalizedEntries. We check each child to see if it is indeed a reference; in which case, it is removed from the document context

## Testing?

I tested the changes against the automated testing suite and the integrated tests, especially integration test 18 which removes several fields as part of it's test.


## New Dependencies?

No

## Screenshots

[Before Fix.pdf](https://github.com/Hopding/pdf-lib/files/7214531/Before.Fix.pdf)
[After Fix.pdf](https://github.com/Hopding/pdf-lib/files/7214533/After.Fix.pdf)


## Suggested Reading?

Partly

## Anything Else?

Linter found style issue in the /src/api/index.ts file. I did not push that change as it was unrelated to this fix.

## Checklist
- [x] I read [CONTRIBUTING.md](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md).
- [x] I read [MAINTAINERSHIP.md#pull-requests](https://github.com/Hopding/pdf-lib/blob/master/docs/MAINTAINERSHIP.md#pull-requests).
- [x] I added/updated unit tests for my changes.
- [x] I added/updated integration tests for my changes.
- [x] I [ran the integration tests](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-integration-tests).
- [x] I tested my changes in Node, Deno, and the browser.
- [x] I viewed documents produced with my changes in Adobe Acrobat, Foxit Reader, Firefox, and Chrome.
- [ ] I added/updated doc comments for any new/modified public APIs.
- [x] My changes work for both **new** and **existing** PDF files.
- [x] I [ran the linter](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-linter) on my changes.
