### PR TITLE
Set page reference for new field Widgets

### DIFF
--- a/src/api/form/PDFButton.ts
+++ b/src/api/form/PDFButton.ts
@@ -181,6 +181,7 @@ export default class PDFButton extends PDFField {
 
     // Add widget to the given page
     page.node.addAnnot(widgetRef);
+    this.updateWidgetPageReference(widget, page.ref);
   }
 
   /**

--- a/src/api/form/PDFCheckBox.ts
+++ b/src/api/form/PDFCheckBox.ts
@@ -182,6 +182,7 @@ export default class PDFCheckBox extends PDFField {
 
     // Add widget to the given page
     page.node.addAnnot(widgetRef);
+    this.updateWidgetPageReference(widget, page.ref);
   }
 
   /**

--- a/src/api/form/PDFDropdown.ts
+++ b/src/api/form/PDFDropdown.ts
@@ -561,6 +561,7 @@ export default class PDFDropdown extends PDFField {
 
     // Add widget to the given page
     page.node.addAnnot(widgetRef);
+    this.updateWidgetPageReference(widget, page.ref);
   }
 
   /**

--- a/src/api/form/PDFField.ts
+++ b/src/api/form/PDFField.ts
@@ -344,6 +344,13 @@ export default class PDFField {
     return widget;
   }
 
+  protected updateWidgetPageReference(
+    widget: PDFWidgetAnnotation,
+    pageRef: PDFRef,
+  ) {
+    widget.dict.set(PDFName.of('P'), pageRef);
+  }
+
   protected updateWidgetAppearanceWithFont(
     widget: PDFWidgetAnnotation,
     font: PDFFont,

--- a/src/api/form/PDFOptionList.ts
+++ b/src/api/form/PDFOptionList.ts
@@ -480,6 +480,7 @@ export default class PDFOptionList extends PDFField {
 
     // Add widget to the given page
     page.node.addAnnot(widgetRef);
+    this.updateWidgetPageReference(widget, page.ref);
   }
 
   /**

--- a/src/api/form/PDFTextField.ts
+++ b/src/api/form/PDFTextField.ts
@@ -742,6 +742,7 @@ export default class PDFTextField extends PDFField {
 
     // Add widget to the given page
     page.node.addAnnot(widgetRef);
+    this.updateWidgetPageReference(widget, page.ref);
   }
 
   /**

--- a/tests/api/form/PDFCheckBox.spec.ts
+++ b/tests/api/form/PDFCheckBox.spec.ts
@@ -52,4 +52,20 @@ describe(`PDFCheckBox`, () => {
     expect(widgets().length).toBe(1);
     expect(widgets()[0].hasFlag(AnnotationFlags.Print)).toBe(true);
   });
+
+  it(`sets page reference when added to a page`, async () => {
+    const pdfDoc = await PDFDocument.create();
+    const page = pdfDoc.addPage();
+
+    const form = pdfDoc.getForm();
+
+    const checkBox = form.createCheckBox('a.new.check.box');
+
+    const widgets = () => checkBox.acroField.getWidgets();
+    expect(widgets().length).toBe(0);
+
+    checkBox.addToPage(page);
+    expect(widgets().length).toBe(1);
+    expect(widgets()[0].P()).toBe(page.ref);
+  });
 });

--- a/tests/api/form/PDFDropdown.spec.ts
+++ b/tests/api/form/PDFDropdown.spec.ts
@@ -99,4 +99,20 @@ describe(`PDFDropdown`, () => {
     expect(widgets().length).toBe(1);
     expect(widgets()[0].hasFlag(AnnotationFlags.Print)).toBe(true);
   });
+
+  it(`sets page reference when added to a page`, async () => {
+    const pdfDoc = await PDFDocument.create();
+    const page = pdfDoc.addPage();
+
+    const form = pdfDoc.getForm();
+
+    const dropdown = form.createDropdown('a.new.dropdown');
+
+    const widgets = () => dropdown.acroField.getWidgets();
+    expect(widgets().length).toBe(0);
+
+    dropdown.addToPage(page);
+    expect(widgets().length).toBe(1);
+    expect(widgets()[0].P()).toBe(page.ref);
+  });
 });

--- a/tests/api/form/PDFOptionList.spec.ts
+++ b/tests/api/form/PDFOptionList.spec.ts
@@ -85,4 +85,20 @@ describe(`PDFOptionList`, () => {
     expect(widgets().length).toBe(1);
     expect(widgets()[0].hasFlag(AnnotationFlags.Print)).toBe(true);
   });
+
+  it(`sets page reference when added to a page`, async () => {
+    const pdfDoc = await PDFDocument.create();
+    const page = pdfDoc.addPage();
+
+    const form = pdfDoc.getForm();
+
+    const optionList = form.createOptionList('a.new.option.list');
+
+    const widgets = () => optionList.acroField.getWidgets();
+    expect(widgets().length).toBe(0);
+
+    optionList.addToPage(page);
+    expect(widgets().length).toBe(1);
+    expect(widgets()[0].P()).toBe(page.ref);
+  });
 });

--- a/tests/api/form/PDFRadioGroup.spec.ts
+++ b/tests/api/form/PDFRadioGroup.spec.ts
@@ -164,4 +164,20 @@ describe(`PDFRadioGroup`, () => {
     expect(widgets().length).toBe(1);
     expect(widgets()[0].hasFlag(AnnotationFlags.Print)).toBe(true);
   });
+
+  it(`sets page reference when added to a page`, async () => {
+    const pdfDoc = await PDFDocument.create();
+    const page = pdfDoc.addPage();
+
+    const form = pdfDoc.getForm();
+
+    const radioGroup = form.createRadioGroup('a.new.radio.group');
+
+    const widgets = () => radioGroup.acroField.getWidgets();
+    expect(widgets().length).toBe(0);
+
+    radioGroup.addOptionToPage('foo', page);
+    expect(widgets().length).toBe(1);
+    expect(widgets()[0].P()).toBe(page.ref);
+  });
 });

--- a/tests/api/form/PDFTextField.spec.ts
+++ b/tests/api/form/PDFTextField.spec.ts
@@ -112,6 +112,22 @@ describe(`PDFTextField`, () => {
     expect(widgets()[0].hasFlag(AnnotationFlags.Print)).toBe(true);
   });
 
+  it(`sets page reference when added to a page`, async () => {
+    const pdfDoc = await PDFDocument.create();
+    const page = pdfDoc.addPage();
+
+    const form = pdfDoc.getForm();
+
+    const textField = form.createTextField('a.new.text.field');
+
+    const widgets = () => textField.acroField.getWidgets();
+    expect(widgets().length).toBe(0);
+
+    textField.addToPage(page);
+    expect(widgets().length).toBe(1);
+    expect(widgets()[0].P()).toBe(page.ref);
+  });
+
   it(`sets the 'hidden' flag when passed options.hidden`, async () => {
     const pdfDoc = await PDFDocument.create();
     const page = pdfDoc.addPage();


### PR DESCRIPTION

## What?

Sets the page reference for field widgets when they are added to a page

## Why?
Currently the library does not set the page reference, causing code intended to find the widget's page to fail. Notably, some internal code is also tripped up by this currently as it uses the same methodology.

Ex:
`

    const pages = PDFDoc.getPages();
    const field = PDFField;
    const widget = field.getWidgets()[0];
    const pageIndex = pages.findIndex(function(x){return x.ref === widget.P()});
    const page = pages[pageIndex];
`

## How?
A function has been added to PDFField **updateWidgetPageReference** that takes the widget annotation and the PDFRef for the page and adds that reference to the widget's dictionary.

This function is called at the end of a fields **addToPage** function just after adding the widget annotation to the page's internal node

## Testing?

I added a unit test for each field that supports an addToPage function. Upon making my changes, I verified that those tests now passed. I also checked the Integration tests to be sure nothing there was messed up. Everything appeared to be in order.


## New Dependencies?

No

## Screenshots

N/A

## Suggested Reading?

Partly

## Anything Else?

Linter found a lint rule violation in the src/api/index.ts file. I did not push that as it was unrelated to this fix

## Checklist
- [X] I read [CONTRIBUTING.md](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md).
- [X] I read [MAINTAINERSHIP.md#pull-requests](https://github.com/Hopding/pdf-lib/blob/master/docs/MAINTAINERSHIP.md#pull-requests).
- [X] I added/updated unit tests for my changes.
- [X] I added/updated integration tests for my changes.
- [X] I [ran the integration tests](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-integration-tests).
- [X] I tested my changes in Node, Deno, and the browser.
- [X] I viewed documents produced with my changes in Adobe Acrobat, Foxit Reader, Firefox, and Chrome.
- [ ] I added/updated doc comments for any new/modified public APIs.
- [X] My changes work for both **new** and **existing** PDF files.
- [X] I [ran the linter](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-linter) on my changes.
