### PR TITLE
Improved memory usage

### DIFF
--- a/src/api/PDFImage.ts
+++ b/src/api/PDFImage.ts
@@ -35,8 +35,8 @@ export default class PDFImage implements Embeddable {
   /** The height of this image in pixels. */
   readonly height: number;
 
-  private alreadyEmbedded = false;
-  private readonly embedder: ImageEmbedder;
+  private embedder: ImageEmbedder | undefined;
+  private embedderTask: Promise<PDFRef> | undefined;
 
   private constructor(ref: PDFRef, doc: PDFDocument, embedder: ImageEmbedder) {
     assertIs(ref, 'ref', [[PDFRef, 'PDFRef']]);
@@ -125,9 +125,15 @@ export default class PDFImage implements Embeddable {
    * @returns Resolves when the embedding is complete.
    */
   async embed(): Promise<void> {
-    if (!this.alreadyEmbedded) {
-      await this.embedder.embedIntoContext(this.doc.context, this.ref);
-      this.alreadyEmbedded = true;
+    const embedder = this.embedder;
+    if (!embedder) return;
+
+    let embedderTask = this.embedderTask;
+    if (!embedderTask) {
+      embedderTask = embedder.embedIntoContext(this.doc.context, this.ref);
+      this.embedderTask = embedderTask;
     }
+    await embedderTask;
+    this.embedder = undefined;
   }
 }

--- a/tests/api/PDFImage.spec.ts
+++ b/tests/api/PDFImage.spec.ts
@@ -1,0 +1,62 @@
+import { PDFDocument, PDFImage } from "src/api";
+import { PngEmbedder } from "src/core";
+import { toUint8Array } from "src/utils";
+
+
+const examplePngImage = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAABhGlDQ1BJQ0MgcHJvZmlsZQAAKJF9kT1Iw0AcxV9TxaoVBzuIdMhQnSyIijhKFYtgobQVWnUwufQLmjQkKS6OgmvBwY/FqoOLs64OroIg+AHi5uak6CIl/i8ptIjx4Lgf7+497t4BQqPCVLNrAlA1y0jFY2I2tyr2vKIfAgLoRVhipp5IL2bgOb7u4ePrXZRneZ/7cwwoeZMBPpF4jumGRbxBPLNp6Zz3iUOsJCnE58TjBl2Q+JHrsstvnIsOCzwzZGRS88QhYrHYwXIHs5KhEk8TRxRVo3wh67LCeYuzWqmx1j35C4N5bSXNdZphxLGEBJIQIaOGMiqwEKVVI8VEivZjHv4Rx58kl0yuMhg5FlCFCsnxg//B727NwtSkmxSMAd0vtv0xCvTsAs26bX8f23bzBPA/A1da219tALOfpNfbWuQIGNwGLq7bmrwHXO4Aw0+6ZEiO5KcpFArA+xl9Uw4YugX61tzeWvs4fQAy1NXyDXBwCIwVKXvd492Bzt7+PdPq7wcdn3KFLu4iBAAAAAZiS0dEAP8A/wD/oL2nkwAAAAlwSFlzAAALEwAACxMBAJqcGAAAAlFJREFUeNrt289r02AYB/Dvk6Sl4EDKpllTlFKsnUdBHXgUBEHwqHj2IJ72B0zwKHhxJ08i/gDxX/AiRfSkBxELXTcVxTa2s2xTsHNN8ngQbQL70RZqG/Z9b29JnvflkydP37whghG3ZaegoxzfwB5vBCAAAQhAAAIQgAAEIAABCEAAAhCAAAQgwB5rstWPtnP0LqBX/vZNyLF6vVrpN/hucewhb4g+B2AyAwiwY7NGOXijviS9vBeYh6CEP4edBLDADCAAAQhAAAIQgAAEIAABCDAUAFF/GIN1DM+PBYCo/ohMXDQ1WPjoeUZH1mMBEEh0oqLGvsHCy0S4NzWVWotJBogbvZB+brDwQT7UWSmXy5sxyQB9HQEROdVv4HQ+vx+QmS4iXsWmCK7Usu8AhOqAXMzlcn3VgWTbugQgEYrxMkZ/gyUPgnuhe2C6/Stxvdeg2ezMJERvhOuoZ+JBrNYBRuDdBtDuXkDM25nCHLbZSv9X6A4VHU+DpwCcbvbjcetLtTaOANtuirrux08HM0euisjDEMKC7RQuq+C+pVJqpzx3NZ3+eeBza9I0rWJgyHnxg2sAJrqnaHUzFcyN60Jox13hprv8aNopZBS4GcqWWVHM+lAkN0zY7ncgkYBukRoKLPpiXVj9UFkfV4Bdl8Jf60u3IMZZAG/6iLuhkDvaSZ74VqtUx3kp3NN7gUZt8RmA43a2eEY1OCfQ04AcBpAGkAKwpkBLIG8BfQE/eNJsvG/G4VlARj0BfjDBx2ECEIAABCAAAQhAAAIQgAAE+P/tN8YvpvbTDBOlAAAAAElFTkSuQmCC";
+
+describe(`PDFImage`, () => {
+
+  describe(`embed() method`, () => {
+    it(`The embedder field should be cleared after the first call to embed()`, async () => {
+      const pdfDoc = await PDFDocument.create();
+
+      const bytes = toUint8Array(examplePngImage);
+      const embedder = await PngEmbedder.for(bytes);
+      const ref = pdfDoc.context.nextRef();
+      const pdfImage = PDFImage.of(ref, pdfDoc, embedder);
+
+      const embedderVariable = "embedder";
+      expect(pdfImage[embedderVariable]).toBeDefined();
+      await pdfImage.embed();
+      expect(pdfImage[embedderVariable]).toBeUndefined();
+    });
+    it(`The method embed() may be called several times without an error`, async () => {
+      const pdfDoc = await PDFDocument.create();
+
+      const bytes = toUint8Array(examplePngImage);
+      const embedder = await PngEmbedder.for(bytes);
+      const ref = pdfDoc.context.nextRef();
+      const pdfImage = PDFImage.of(ref, pdfDoc, embedder);
+
+      const noErrorFunc = async () => {
+        await pdfImage.embed();
+        await pdfImage.embed();
+      }
+
+      await expect(noErrorFunc()).resolves.not.toThrowError();
+    });
+    it(`The method embed() may be called parallel without causing an error`, async () => {
+      const pdfDoc = await PDFDocument.create();
+
+      const bytes = toUint8Array(examplePngImage);
+      const embedder = await PngEmbedder.for(bytes);
+      const ref = pdfDoc.context.nextRef();
+      const pdfImage = PDFImage.of(ref, pdfDoc, embedder);
+
+      const noErrorFunc = async () => {
+        const embedderTaskVariable = "embedderTask";
+        const undefinedTask = pdfImage[embedderTaskVariable];
+        expect(undefinedTask).toBeUndefined();
+        const task1 = pdfImage.embed();
+        const firstTask = pdfImage[embedderTaskVariable];
+        const task2 = pdfImage.embed();
+        const secondTask = pdfImage[embedderTaskVariable];
+        await Promise.all([task1, task2]);
+        expect(firstTask).toEqual(secondTask);
+      }
+
+      await expect(noErrorFunc()).resolves.not.toThrowError();
+    });
+  });
+});


### PR DESCRIPTION
We have been using pdf-lib for the last 4 months to generate our PDFs on the WEB and on the server. I noticed that for a PDF with 180 pages and high resolution PNGs, the RAM usage increases a lot (~6GB). 

My code change ensures that after a `page.drawImage` you can directly call an `image.embed()`.

This decodes and encodes the image immediately and remove the decoded image from RAM immediately.
With this change I have the same performance but a maximum RAM usage of 220MB.

Usage without these changes:
![image](https://user-images.githubusercontent.com/14217001/137353918-ecf42a78-dd5f-4257-b4c6-399fb8e746c1.png)
Max RAM usage:
![image](https://user-images.githubusercontent.com/14217001/137353948-b793bce0-2c0c-4bd5-90ff-0aa53476658b.png)


Usage with these changes:
![image](https://user-images.githubusercontent.com/14217001/137353970-c40b6046-0879-494c-8f95-06c90a3245bf.png)
Max RAM usage:
![image](https://user-images.githubusercontent.com/14217001/137353994-18fc7e40-a9a8-4814-89e6-8b17b72f4cfa.png)
