### PR TITLE
Mark package as sideEffect free in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "apps:rn:android": "yarn apps:rn:emulator & cd apps/rn && yarn add ./../.. --force && react-native run-android",
     "apps:rn:emulator": "emulator -avd \"$(emulator -list-avds | head -n 1)\" & bash -c 'sleep 5 && adb reverse tcp:8080 tcp:8080 && adb reverse tcp:8081 tcp:8081'"
   },
+  "sideEffects": false,
   "main": "cjs/index.js",
   "module": "es/index.js",
   "unpkg": "dist/pdf-lib.min.js",


### PR DESCRIPTION
Hi @Hopding!

I'm utilising this library in a slightly different way from most, I'm just using the low-level primitives available in `/core` and creating PDFs semi-manually. This library is amazingly flexible, and means I don't have to re-implement difficult things like image/font loading. Hurrah!

However, despite using the ESM build (`pdf-lib/es/index.js`), many bundlers still bundle the entire library by default.

As a simple example, the file below only has one `pdf-lib` import:

```js
// in.js
import { PDFRef } from "pdf-lib";
console.log(PDFRef);
```

Yet bundling with ESbuild...
`esbuild --bundle ./in.js --minify --outfile=out.js`
...gives an output size of `425.8kb`, which is the whole library!

If `pdf-lib` declared itself as side-effect free, bundlers can be more aggressive with tree-shaking, and remove unused exports. I believe pdf-lib can do so, because all modules are self-contained and don't modify each other or global scope.

The same test with this PR applied... `13.9kb`!

For more info, here's Webpack's documentation on this setting:
https://webpack.js.org/guides/tree-shaking/#mark-the-file-as-side-effect-free

Finally - thank you for your hard work on this library! 👌 