### PR TITLE
Improve performance of layoutMultilineText

### DIFF
--- a/src/api/text/layout.ts
+++ b/src/api/text/layout.ts
@@ -143,18 +143,24 @@ const splitOutLines = (
         let line = '';
         let remainder;
         if (/\s/.test(s)) {
-          line = tokens.map((token, i) => token + (whitespaces[i] ?? '')).join('');
+          line = tokens
+            .map((token, tokenIdx) => token + (whitespaces[tokenIdx] ?? ''))
+            .join('');
           remainder = input.substring(i) || undefined;
         } else {
-          // We're in the middle of a token so go back to the last token and 
+          // We're in the middle of a token so go back to the last token and
           // adjust remainder based on the length of the current incomplete token
-          line = tokens.slice(0, tokens.length - 1).map((token, i) => token + (whitespaces[i] ?? '')).join('');
-          
-          const whitespaceLength = (whitespaces[whitespaces.length - 1] || '').length;
+          line = tokens
+            .slice(0, tokens.length - 1)
+            .map((token, tokenIdx) => token + (whitespaces[tokenIdx] ?? ''))
+            .join('');
+
+          const whitespaceLength = (whitespaces[whitespaces.length - 1] || '')
+            .length;
           const tokenLength = (tokens[tokens.length - 1] || '').length;
           if (whitespaceLength === 0) {
-              // Not able to layout this input within the maxWidth.
-              break;
+            // Not able to layout this input within the maxWidth.
+            break;
           }
           const remainderIndex = i - whitespaceLength - tokenLength;
           remainder = input.substring(remainderIndex) || undefined;
@@ -164,12 +170,12 @@ const splitOutLines = (
           line,
           encoded: font.encodeText(line),
           width: font.widthOfTextAtSize(line, fontSize),
-          remainder
+          remainder,
         };
       }
 
       if (/\s/.test(s)) {
-        // Found a word boundary. 
+        // Found a word boundary.
         // We will add each subsequent character to the current token until we find another word boundary.
         whitespaces.push(s);
         tokens.push('');

--- a/src/api/text/layout.ts
+++ b/src/api/text/layout.ts
@@ -124,29 +124,61 @@ export interface MultilineTextLayout {
   lineHeight: number;
 }
 
-const lastIndexOfWhitespace = (line: string) => {
-  for (let idx = line.length; idx > 0; idx--) {
-    if (/\s/.test(line[idx])) return idx;
-  }
-  return undefined;
-};
-
 const splitOutLines = (
   input: string,
   maxWidth: number,
   font: PDFFont,
   fontSize: number,
 ) => {
-  let lastWhitespaceIdx = input.length;
-  while (lastWhitespaceIdx > 0) {
-    const line = input.substring(0, lastWhitespaceIdx);
-    const encoded = font.encodeText(line);
-    const width = font.widthOfTextAtSize(line, fontSize);
-    if (width < maxWidth) {
-      const remainder = input.substring(lastWhitespaceIdx) || undefined;
-      return { line, encoded, width, remainder };
+  if (font.widthOfTextAtSize(input, fontSize) > maxWidth) {
+    const tokens: string[] = [''];
+    const whitespaces: string[] = [];
+    let width = 0;
+
+    for (let i = 0; i < input.length; i++) {
+      const s = input[i];
+
+      // If this character puts us over then we're done.
+      if (width + font.widthOfTextAtSize(s, fontSize) >= maxWidth) {
+        let line = '';
+        let remainder;
+        if (/\s/.test(s)) {
+          line = tokens.map((token, i) => token + (whitespaces[i] ?? '')).join('');
+          remainder = input.substring(i) || undefined;
+        } else {
+          // We're in the middle of a token so go back to the last token and 
+          // adjust remainder based on the length of the current incomplete token
+          line = tokens.slice(0, tokens.length - 1).map((token, i) => token + (whitespaces[i] ?? '')).join('');
+          
+          const whitespaceLength = (whitespaces[whitespaces.length - 1] || '').length;
+          const tokenLength = (tokens[tokens.length - 1] || '').length;
+          if (whitespaceLength === 0) {
+              // Not able to layout this input within the maxWidth.
+              break;
+          }
+          const remainderIndex = i - whitespaceLength - tokenLength;
+          remainder = input.substring(remainderIndex) || undefined;
+        }
+
+        return {
+          line,
+          encoded: font.encodeText(line),
+          width: font.widthOfTextAtSize(line, fontSize),
+          remainder
+        };
+      }
+
+      if (/\s/.test(s)) {
+        // Found a word boundary. 
+        // We will add each subsequent character to the current token until we find another word boundary.
+        whitespaces.push(s);
+        tokens.push('');
+      } else {
+        tokens[tokens.length - 1] += s;
+      }
+
+      width += font.widthOfTextAtSize(s, fontSize);
     }
-    lastWhitespaceIdx = lastIndexOfWhitespace(line) ?? 0;
   }
 
   // We were unable to split the input enough to get a chunk that would fit

--- a/tests/api/text/layout.spec.ts
+++ b/tests/api/text/layout.spec.ts
@@ -163,4 +163,34 @@ describe(`layoutMultilineText`, () => {
       expect(multilineTextLayout.lines.length).toStrictEqual(3);
     }
   });
+
+  it('should layout the text when width is too short to contain it', async () => {
+    const pdfDoc = await PDFDocument.create();
+    const font = await pdfDoc.embedFont(StandardFonts.Helvetica);
+    const alignment = TextAlignment.Left;
+    const padding = 0;
+    const borderWidth = 0;
+    const text = 'Super Mario Bros.';
+
+    for (let fontSize = MIN_FONT_SIZE; fontSize <= MAX_FONT_SIZE; fontSize++) {
+      const height = font.heightAtSize(fontSize) - (borderWidth + padding) * 2;
+
+      const width = 1;
+
+      const bounds = {
+        x: borderWidth + padding,
+        y: borderWidth + padding,
+        width,
+        height,
+      };
+
+      const multilineTextLayout = layoutMultilineText(text, {
+        alignment,
+        bounds,
+        font,
+      });
+
+      expect(multilineTextLayout.lines.length).toStrictEqual(1);
+    }
+  });
 });


### PR DESCRIPTION
<!-- 
👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇
👉 🚨 Do not remove or skip any sections in this template ⛔️ 👈
👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆

Thank you for taking the time to make a PR! 💖 
Please fill out this template completely to help us provide a prompt review. 😃
You can add more sections if you like. ✅
-->

## What?
Addresses: https://github.com/Hopding/pdf-lib/issues/1202. Previously long strings (> 10k characters) took very long for this function to execute (> 30 seconds). With this fix, a 10k character string executes in less than 1 second.

## Testing?
- Added a unit test
- Executed integration tests (and fixed an issue that test number 15 uncovered)
- A lot of testing using the scratchpad.

## New Dependencies?
None

## Checklist
- [X] I read [CONTRIBUTING.md](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md).
- [X] I read [MAINTAINERSHIP.md#pull-requests](https://github.com/Hopding/pdf-lib/blob/master/docs/MAINTAINERSHIP.md#pull-requests).
- [X] I added/updated unit tests for my changes.
- [ ] I added/updated integration tests for my changes.
- [X] I [ran the integration tests](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-integration-tests).
- [X] I tested my changes in Node, Deno, and the browser.
- [X] I viewed documents produced with my changes in Adobe Acrobat, Foxit Reader, Firefox, and Chrome.
- [ ] I added/updated doc comments for any new/modified public APIs.
- [X] My changes work for both **new** and **existing** PDF files.
- [X] I [ran the linter](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-linter) on my changes.
