### PR TITLE
Make stream parser resilient to text in streams

### DIFF
--- a/src/core/parser/PDFObjectParser.ts
+++ b/src/core/parser/PDFObjectParser.ts
@@ -243,14 +243,25 @@ class PDFObjectParser extends BaseParser {
 
   protected findEndOfStreamFallback(startPos: Position) {
     // Move to end of stream, while handling nested streams
+    let acceptUnprefixedStream = true;
     let nestingLvl = 1;
     let end = this.bytes.offset();
 
     while (!this.bytes.done()) {
       end = this.bytes.offset();
 
-      if (this.matchKeyword(Keywords.stream)) {
+      if (
+        this.matchKeyword(Keywords.embeddedStream1) ||
+        this.matchKeyword(Keywords.embeddedStream2) ||
+        this.matchKeyword(Keywords.embeddedStream3) ||
+        this.matchKeyword(Keywords.embeddedStream4) ||
+        this.matchKeyword(Keywords.embeddedStream5) ||
+        this.matchKeyword(Keywords.embeddedStream6) ||
+        this.matchKeyword(Keywords.embeddedStream7) ||
+        (acceptUnprefixedStream && this.matchKeyword(Keywords.stream))
+      ) {
         nestingLvl += 1;
+        acceptUnprefixedStream = true;
       } else if (
         this.matchKeyword(Keywords.EOF1endstream) ||
         this.matchKeyword(Keywords.EOF2endstream) ||
@@ -258,8 +269,10 @@ class PDFObjectParser extends BaseParser {
         this.matchKeyword(Keywords.endstream)
       ) {
         nestingLvl -= 1;
+        acceptUnprefixedStream = true;
       } else {
         this.bytes.next();
+        acceptUnprefixedStream = false;
       }
 
       if (nestingLvl === 0) break;

--- a/src/core/syntax/Keywords.ts
+++ b/src/core/syntax/Keywords.ts
@@ -1,6 +1,6 @@
 import CharCodes from 'src/core/syntax/CharCodes';
 
-const { Space, CarriageReturn, Newline } = CharCodes;
+const { Space, CarriageReturn, Newline, Tab, LessThan, GreaterThan, BackSlash } = CharCodes;
 
 const stream = [
   CharCodes.s,
@@ -76,6 +76,13 @@ export const Keywords = {
   streamEOF2: [...stream, CarriageReturn, Newline],
   streamEOF3: [...stream, CarriageReturn],
   streamEOF4: [...stream, Newline],
+  embeddedStream1: [Tab, ...stream],
+  embeddedStream2: [Space, ...stream],
+  embeddedStream3: [CarriageReturn, ...stream],
+  embeddedStream4: [Newline, ...stream],
+  embeddedStream5: [LessThan, ...stream],
+  embeddedStream6: [GreaterThan, ...stream],
+  embeddedStream7: [BackSlash, ...stream],
   endstream,
   EOF1endstream: [CarriageReturn, Newline, ...endstream],
   EOF2endstream: [CarriageReturn, ...endstream],

--- a/src/core/syntax/Keywords.ts
+++ b/src/core/syntax/Keywords.ts
@@ -1,6 +1,14 @@
 import CharCodes from 'src/core/syntax/CharCodes';
 
-const { Space, CarriageReturn, Newline, Tab, LessThan, GreaterThan, BackSlash } = CharCodes;
+const {
+  Space,
+  CarriageReturn,
+  Newline,
+  Tab,
+  LessThan,
+  GreaterThan,
+  BackSlash,
+} = CharCodes;
 
 const stream = [
   CharCodes.s,

--- a/tests/core/parser/PDFObjectParser.spec.ts
+++ b/tests/core/parser/PDFObjectParser.spec.ts
@@ -576,6 +576,10 @@ describe(`PDFObjectParser`, () => {
         '<<>>\n\rstream\n\rthingz\n\rendstream',
         '<<\n/Length 8\n>>\nstream\n\rthingz\n\nendstream',
       ],
+      [
+        '<<>>\n\rstream\n\rthingz bitstream\n\rendstream',
+        '<<\n/Length 18\n>>\nstream\n\rthingz bitstream\n\nendstream',
+      ],
     ].forEach(([input, output]) => {
       it(`can parse ${JSON.stringify(input)}`, () => {
         const object = parse(typedArrayFor(input));


### PR DESCRIPTION
<!-- 
👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇
👉 🚨 Do not remove or skip any sections in this template ⛔️ 👈
👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆

Thank you for taking the time to make a PR! 💖 
Please fill out this template completely to help us provide a prompt review. 😃
You can add more sections if you like. ✅
-->

## What?
Updates the streamParser to ignore the keyword 'stream' if it is not proceeded by a special character. Fixes #1206 

## Why?
Some font files when embedded include their license information, one font where this occurred included the word 'bitstream' several times which confused the streamParser. The streamParser thought there were more open streams than there were.

## How?
The word 'stream' should be proceeded by a space, newline, carriage return, backslash, lessThan, or greaterThan character. I also included tabs for good measure. If the word 'stream' is not proceeded by one of those characters, it is ignored.

There is a special case just after a 'stream' is consumed, we set a flag that allows an immediately following 'stream' to be counted.

## Testing?
I added a test to the testing suite that exercised the fail condition with the current parser, then updated the parser to pass the new test.


## New Dependencies?
NA

## Screenshots
NA

## Suggested Reading?
NA

## Anything Else?
NA

## Checklist
- [X] I read [CONTRIBUTING.md](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md).
- [X] I read [MAINTAINERSHIP.md#pull-requests](https://github.com/Hopding/pdf-lib/blob/master/docs/MAINTAINERSHIP.md#pull-requests).
- [X] I added/updated unit tests for my changes.
- [ ] I added/updated integration tests for my changes.
- [X] I [ran the integration tests](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-integration-tests).
- [X] I tested my changes in Node, Deno, and the browser.
- [X] I viewed documents produced with my changes in Adobe Acrobat, Foxit Reader, Firefox, and Chrome.
- [X] I added/updated doc comments for any new/modified public APIs.
- [X] My changes work for both **new** and **existing** PDF files.
- [X] I [ran the linter](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-linter) on my changes.
