### PR TITLE
Provide all text state operators

### DIFF
--- a/apps/deno/tests/test1.ts
+++ b/apps/deno/tests/test1.ts
@@ -646,6 +646,67 @@ export default async (assets: Assets) => {
 
   form.removeField(textField);
 
+  /********************** Page 6 **********************/
+  // This page tests different drawing operations as well as adding custom
+  // operators to the page content.
+
+  const page6 = pdfDoc.addPage([size, size]);
+
+  const text = "These are the test words. "
+  page6.drawText(text + 'regular', {
+    y: size - 20,
+    size: 20,
+    lineHeight: 20,
+    //horizontalScale: 50,
+    //rise: 0,
+    //wordSpace: 10,
+    //characterSpace: -2,
+  });
+  page6.drawText(text + '+5 raised and fontsize 12 instead of 20', {
+    y: size - 20,
+    x: 325,
+    size: 12,
+    lineHeight: 20,
+    //horizontalScale: 50,
+    rise: 5,
+    //wordSpace: 10,
+    //characterSpace: -2,
+  });
+  page6.drawText(text + '50% horizontal scale', {
+    y: size - 40,
+    size: 20,
+    lineHeight: 20,
+    horizontalScale: 50,
+    //rise: 0,
+    //wordSpace: 10,
+    //characterSpace: -2,
+  });
+  page6.drawText(text + '+10 word space', {
+    y: size - 60,
+    size: 20,
+    lineHeight: 20,
+    //horizontalScale: 50,
+    //rise: 0,
+    wordSpace: 10,
+    //characterSpace: -2,
+    renderingMode: TextRenderingMode.Outline,
+  });
+  page6.drawText(text + '+4 character space', {
+    y: size - 80,
+    size: 20,
+    lineHeight: 20,
+    //horizontalScale: 50,
+    //rise: 0,
+    //wordSpace: 10,
+    characterSpace: 4,
+  });
+  page6.drawText(text + 'textRenderingMode = outline', {
+    y: size - 100,
+    size: 20,
+    lineHeight: 20,
+    renderingMode: TextRenderingMode.Outline,
+  });
+
   /********************** Print Metadata **********************/
 
   console.log('Title:', pdfDoc.getTitle());

--- a/apps/deno/tests/test1.ts
+++ b/apps/deno/tests/test1.ts
@@ -23,6 +23,7 @@ import {
   setLineJoin,
   StandardFonts,
   AFRelationship,
+  TextRenderingMode,
 } from '../../../dist/pdf-lib.esm.js';
 
 const ipsumLines = [
@@ -657,47 +658,30 @@ export default async (assets: Assets) => {
     y: size - 20,
     size: 20,
     lineHeight: 20,
-    //horizontalScale: 50,
-    //rise: 0,
-    //wordSpace: 10,
-    //characterSpace: -2,
   });
   page6.drawText(text + '+5 raised and fontsize 12 instead of 20', {
     y: size - 20,
     x: 325,
     size: 12,
     lineHeight: 20,
-    //horizontalScale: 50,
     rise: 5,
-    //wordSpace: 10,
-    //characterSpace: -2,
   });
   page6.drawText(text + '50% horizontal scale', {
     y: size - 40,
     size: 20,
     lineHeight: 20,
     horizontalScale: 50,
-    //rise: 0,
-    //wordSpace: 10,
-    //characterSpace: -2,
   });
   page6.drawText(text + '+10 word space', {
     y: size - 60,
     size: 20,
     lineHeight: 20,
-    //horizontalScale: 50,
-    //rise: 0,
     wordSpace: 10,
-    //characterSpace: -2,
-    renderingMode: TextRenderingMode.Outline,
   });
   page6.drawText(text + '+4 character space', {
     y: size - 80,
     size: 20,
     lineHeight: 20,
-    //horizontalScale: 50,
-    //rise: 0,
-    //wordSpace: 10,
     characterSpace: 4,
   });
   page6.drawText(text + 'textRenderingMode = outline', {

--- a/apps/deno/tests/test1.ts
+++ b/apps/deno/tests/test1.ts
@@ -653,7 +653,7 @@ export default async (assets: Assets) => {
 
   const page6 = pdfDoc.addPage([size, size]);
 
-  const text = "These are the test words. "
+  const text = 'These are the test words. ';
   page6.drawText(text + 'regular', {
     y: size - 20,
     size: 20,

--- a/apps/node/index.ts
+++ b/apps/node/index.ts
@@ -5,7 +5,7 @@ import { sep } from 'path';
 import readline from 'readline';
 
 import test1 from './tests/test1';
-/*import test2 from './tests/test2';
+import test2 from './tests/test2';
 import test3 from './tests/test3';
 import test4 from './tests/test4';
 import test5 from './tests/test5';
@@ -21,7 +21,7 @@ import test14 from './tests/test14';
 import test15 from './tests/test15';
 import test16 from './tests/test16';
 import test17 from './tests/test17';
-import test18 from './tests/test18';*/
+import test18 from './tests/test18';
 
 const cli = readline.createInterface({
   input: process.stdin,
@@ -162,8 +162,8 @@ const main = async () => {
 
     // prettier-ignore
     const allTests = [
-      test1//, test2, test3, test4, test5, test6, test7, test8, test9, test10,
-      //test11, test12, test13, test14, test15, test16, test17, test18, 
+      test1, test2, test3, test4, test5, test6, test7, test8, test9, test10,
+      test11, test12, test13, test14, test15, test16, test17, test18, 
     ];
 
     const tests = testIdx ? [allTests[testIdx - 1]] : allTests;

--- a/apps/node/index.ts
+++ b/apps/node/index.ts
@@ -5,7 +5,7 @@ import { sep } from 'path';
 import readline from 'readline';
 
 import test1 from './tests/test1';
-import test2 from './tests/test2';
+/*import test2 from './tests/test2';
 import test3 from './tests/test3';
 import test4 from './tests/test4';
 import test5 from './tests/test5';
@@ -21,7 +21,7 @@ import test14 from './tests/test14';
 import test15 from './tests/test15';
 import test16 from './tests/test16';
 import test17 from './tests/test17';
-import test18 from './tests/test18';
+import test18 from './tests/test18';*/
 
 const cli = readline.createInterface({
   input: process.stdin,
@@ -162,8 +162,8 @@ const main = async () => {
 
     // prettier-ignore
     const allTests = [
-      test1, test2, test3, test4, test5, test6, test7, test8, test9, test10,
-      test11, test12, test13, test14, test15, test16, test17, test18, 
+      test1//, test2, test3, test4, test5, test6, test7, test8, test9, test10,
+      //test11, test12, test13, test14, test15, test16, test17, test18, 
     ];
 
     const tests = testIdx ? [allTests[testIdx - 1]] : allTests;

--- a/apps/node/tests/test1.ts
+++ b/apps/node/tests/test1.ts
@@ -21,7 +21,6 @@ import {
   StandardFonts,
   typedArrayFor,
   AFRelationship,
-  TextRenderingMode,
 } from '../../..';
 
 const ipsumLines = [
@@ -644,69 +643,6 @@ export default async (assets: Assets) => {
   });
 
   form.removeField(textField);
-
-  // This page tests different drawing operations as well as adding custom
-  // operators to the page content.
-
-  const page6 = pdfDoc.addPage([size, size]);
-
-  // Upper-left Quadrant
-  page6.moveTo(0, size / 2);
-
-  const text = "These are the test words. "
-  page6.drawText(text + 'regular', {
-    y: size - 20,
-    size: 20,
-    lineHeight: 20,
-    //horizontalScale: 50,
-    //rise: 0,
-    //wordSpace: 10,
-    //characterSpace: -2,
-  });
-  page6.drawText(text + '+5 raised and fontsize 12 instead of 20', {
-    y: size - 20,
-    x: 325,
-    size: 12,
-    lineHeight: 20,
-    //horizontalScale: 50,
-    rise: 5,
-    //wordSpace: 10,
-    //characterSpace: -2,
-  });
-  page6.drawText(text + '50% horizontal scale', {
-    y: size - 40,
-    size: 20,
-    lineHeight: 20,
-    horizontalScale: 50,
-    //rise: 0,
-    //wordSpace: 10,
-    //characterSpace: -2,
-  });
-  page6.drawText(text + '+10 word space', {
-    y: size - 60,
-    size: 20,
-    lineHeight: 20,
-    //horizontalScale: 50,
-    //rise: 0,
-    wordSpace: 10,
-    //characterSpace: -2,
-    renderingMode: TextRenderingMode.Outline,
-  });
-  page6.drawText(text + '+4 character space', {
-    y: size - 80,
-    size: 20,
-    lineHeight: 20,
-    //horizontalScale: 50,
-    //rise: 0,
-    //wordSpace: 10,
-    characterSpace: 4,
-  });
-  page6.drawText(text + 'textRenderingMode = outline', {
-    y: size - 100,
-    size: 20,
-    lineHeight: 20,
-    renderingMode: TextRenderingMode.Outline,
-  });
 
   /********************** Print Metadata **********************/
 

--- a/apps/node/tests/test1.ts
+++ b/apps/node/tests/test1.ts
@@ -21,6 +21,7 @@ import {
   StandardFonts,
   typedArrayFor,
   AFRelationship,
+  TextRenderingMode,
 } from '../../..';
 
 const ipsumLines = [

--- a/apps/node/tests/test1.ts
+++ b/apps/node/tests/test1.ts
@@ -21,6 +21,7 @@ import {
   StandardFonts,
   typedArrayFor,
   AFRelationship,
+  TextRenderingMode,
 } from '../../..';
 
 const ipsumLines = [
@@ -643,6 +644,69 @@ export default async (assets: Assets) => {
   });
 
   form.removeField(textField);
+
+  // This page tests different drawing operations as well as adding custom
+  // operators to the page content.
+
+  const page6 = pdfDoc.addPage([size, size]);
+
+  // Upper-left Quadrant
+  page6.moveTo(0, size / 2);
+
+  const text = "These are the test words. "
+  page6.drawText(text + 'regular', {
+    y: size - 20,
+    size: 20,
+    lineHeight: 20,
+    //horizontalScale: 50,
+    //rise: 0,
+    //wordSpace: 10,
+    //characterSpace: -2,
+  });
+  page6.drawText(text + '+5 raised and fontsize 12 instead of 20', {
+    y: size - 20,
+    x: 325,
+    size: 12,
+    lineHeight: 20,
+    //horizontalScale: 50,
+    rise: 5,
+    //wordSpace: 10,
+    //characterSpace: -2,
+  });
+  page6.drawText(text + '50% horizontal scale', {
+    y: size - 40,
+    size: 20,
+    lineHeight: 20,
+    horizontalScale: 50,
+    //rise: 0,
+    //wordSpace: 10,
+    //characterSpace: -2,
+  });
+  page6.drawText(text + '+10 word space', {
+    y: size - 60,
+    size: 20,
+    lineHeight: 20,
+    //horizontalScale: 50,
+    //rise: 0,
+    wordSpace: 10,
+    //characterSpace: -2,
+    renderingMode: TextRenderingMode.Outline,
+  });
+  page6.drawText(text + '+4 character space', {
+    y: size - 80,
+    size: 20,
+    lineHeight: 20,
+    //horizontalScale: 50,
+    //rise: 0,
+    //wordSpace: 10,
+    characterSpace: 4,
+  });
+  page6.drawText(text + 'textRenderingMode = outline', {
+    y: size - 100,
+    size: 20,
+    lineHeight: 20,
+    renderingMode: TextRenderingMode.Outline,
+  });
 
   /********************** Print Metadata **********************/
 

--- a/apps/node/tests/test1.ts
+++ b/apps/node/tests/test1.ts
@@ -651,52 +651,35 @@ export default async (assets: Assets) => {
 
   const page6 = pdfDoc.addPage([size, size]);
 
-  const text = "These are the test words. "
+  const text = 'These are the test words. ';
   page6.drawText(text + 'regular', {
     y: size - 20,
     size: 20,
     lineHeight: 20,
-    //horizontalScale: 50,
-    //rise: 0,
-    //wordSpace: 10,
-    //characterSpace: -2,
   });
   page6.drawText(text + '+5 raised and fontsize 12 instead of 20', {
     y: size - 20,
     x: 325,
     size: 12,
     lineHeight: 20,
-    //horizontalScale: 50,
     rise: 5,
-    //wordSpace: 10,
-    //characterSpace: -2,
   });
   page6.drawText(text + '50% horizontal scale', {
     y: size - 40,
     size: 20,
     lineHeight: 20,
     horizontalScale: 50,
-    //rise: 0,
-    //wordSpace: 10,
-    //characterSpace: -2,
   });
   page6.drawText(text + '+10 word space', {
     y: size - 60,
     size: 20,
     lineHeight: 20,
-    //horizontalScale: 50,
-    //rise: 0,
     wordSpace: 10,
-    //characterSpace: -2,
-    renderingMode: TextRenderingMode.Outline,
   });
   page6.drawText(text + '+4 character space', {
     y: size - 80,
     size: 20,
     lineHeight: 20,
-    //horizontalScale: 50,
-    //rise: 0,
-    //wordSpace: 10,
     characterSpace: 4,
   });
   page6.drawText(text + 'textRenderingMode = outline', {

--- a/apps/node/tests/test1.ts
+++ b/apps/node/tests/test1.ts
@@ -645,13 +645,11 @@ export default async (assets: Assets) => {
 
   form.removeField(textField);
 
+  /********************** Page 6 **********************/
   // This page tests different drawing operations as well as adding custom
   // operators to the page content.
 
   const page6 = pdfDoc.addPage([size, size]);
-
-  // Upper-left Quadrant
-  page6.moveTo(0, size / 2);
 
   const text = "These are the test words. "
   page6.drawText(text + 'regular', {

--- a/apps/rn/src/tests/test1.js
+++ b/apps/rn/src/tests/test1.js
@@ -679,6 +679,67 @@ export default async () => {
 
   form.removeField(textField);
 
+  /********************** Page 6 **********************/
+  // This page tests different drawing operations as well as adding custom
+  // operators to the page content.
+
+  const page6 = pdfDoc.addPage([size, size]);
+
+  const text = "These are the test words. "
+  page6.drawText(text + 'regular', {
+    y: size - 20,
+    size: 20,
+    lineHeight: 20,
+    //horizontalScale: 50,
+    //rise: 0,
+    //wordSpace: 10,
+    //characterSpace: -2,
+  });
+  page6.drawText(text + '+5 raised and fontsize 12 instead of 20', {
+    y: size - 20,
+    x: 325,
+    size: 12,
+    lineHeight: 20,
+    //horizontalScale: 50,
+    rise: 5,
+    //wordSpace: 10,
+    //characterSpace: -2,
+  });
+  page6.drawText(text + '50% horizontal scale', {
+    y: size - 40,
+    size: 20,
+    lineHeight: 20,
+    horizontalScale: 50,
+    //rise: 0,
+    //wordSpace: 10,
+    //characterSpace: -2,
+  });
+  page6.drawText(text + '+10 word space', {
+    y: size - 60,
+    size: 20,
+    lineHeight: 20,
+    //horizontalScale: 50,
+    //rise: 0,
+    wordSpace: 10,
+    //characterSpace: -2,
+    renderingMode: TextRenderingMode.Outline,
+  });
+  page6.drawText(text + '+4 character space', {
+    y: size - 80,
+    size: 20,
+    lineHeight: 20,
+    //horizontalScale: 50,
+    //rise: 0,
+    //wordSpace: 10,
+    characterSpace: 4,
+  });
+  page6.drawText(text + 'textRenderingMode = outline', {
+    y: size - 100,
+    size: 20,
+    lineHeight: 20,
+    renderingMode: TextRenderingMode.Outline,
+  });
+
   /********************** Print Metadata **********************/
 
   console.log('Title:', pdfDoc.getTitle());

--- a/apps/rn/src/tests/test1.js
+++ b/apps/rn/src/tests/test1.js
@@ -20,6 +20,7 @@ import {
   setLineJoin,
   StandardFonts,
   AFRelationship,
+  TextRenderingMode,
 } from 'pdf-lib';
 
 import { fetchAsset } from './assets';
@@ -685,52 +686,35 @@ export default async () => {
 
   const page6 = pdfDoc.addPage([size, size]);
 
-  const text = "These are the test words. "
+  const text = 'These are the test words. ';
   page6.drawText(text + 'regular', {
     y: size - 20,
     size: 20,
     lineHeight: 20,
-    //horizontalScale: 50,
-    //rise: 0,
-    //wordSpace: 10,
-    //characterSpace: -2,
   });
   page6.drawText(text + '+5 raised and fontsize 12 instead of 20', {
     y: size - 20,
     x: 325,
     size: 12,
     lineHeight: 20,
-    //horizontalScale: 50,
     rise: 5,
-    //wordSpace: 10,
-    //characterSpace: -2,
   });
   page6.drawText(text + '50% horizontal scale', {
     y: size - 40,
     size: 20,
     lineHeight: 20,
     horizontalScale: 50,
-    //rise: 0,
-    //wordSpace: 10,
-    //characterSpace: -2,
   });
   page6.drawText(text + '+10 word space', {
     y: size - 60,
     size: 20,
     lineHeight: 20,
-    //horizontalScale: 50,
-    //rise: 0,
     wordSpace: 10,
-    //characterSpace: -2,
-    renderingMode: TextRenderingMode.Outline,
   });
   page6.drawText(text + '+4 character space', {
     y: size - 80,
     size: 20,
     lineHeight: 20,
-    //horizontalScale: 50,
-    //rise: 0,
-    //wordSpace: 10,
     characterSpace: 4,
   });
   page6.drawText(text + 'textRenderingMode = outline', {

--- a/apps/web/test1.html
+++ b/apps/web/test1.html
@@ -79,6 +79,7 @@
         rgb,
         StandardFonts,
         AFRelationship,
+        TextRenderingMode,
       } = PDFLib;
 
       const pdfDoc = await PDFDocument.create();
@@ -758,59 +759,42 @@
       });
 
       form.removeField(textField);
-      
+
       /********************** Page 6 **********************/
       // This page tests different drawing operations as well as adding custom
       // operators to the page content.
 
       const page6 = pdfDoc.addPage([size, size]);
 
-      const text = "These are the test words. "
+      const text = 'These are the test words. ';
       page6.drawText(text + 'regular', {
         y: size - 20,
         size: 20,
         lineHeight: 20,
-        //horizontalScale: 50,
-        //rise: 0,
-        //wordSpace: 10,
-        //characterSpace: -2,
       });
       page6.drawText(text + '+5 raised and fontsize 12 instead of 20', {
         y: size - 20,
         x: 325,
         size: 12,
         lineHeight: 20,
-        //horizontalScale: 50,
         rise: 5,
-        //wordSpace: 10,
-        //characterSpace: -2,
       });
       page6.drawText(text + '50% horizontal scale', {
         y: size - 40,
         size: 20,
         lineHeight: 20,
         horizontalScale: 50,
-        //rise: 0,
-        //wordSpace: 10,
-        //characterSpace: -2,
       });
       page6.drawText(text + '+10 word space', {
         y: size - 60,
         size: 20,
         lineHeight: 20,
-        //horizontalScale: 50,
-        //rise: 0,
         wordSpace: 10,
-        //characterSpace: -2,
-        renderingMode: TextRenderingMode.Outline,
       });
       page6.drawText(text + '+4 character space', {
         y: size - 80,
         size: 20,
         lineHeight: 20,
-        //horizontalScale: 50,
-        //rise: 0,
-        //wordSpace: 10,
         characterSpace: 4,
       });
       page6.drawText(text + 'textRenderingMode = outline', {

--- a/apps/web/test1.html
+++ b/apps/web/test1.html
@@ -758,6 +758,67 @@
       });
 
       form.removeField(textField);
+      
+      /********************** Page 6 **********************/
+      // This page tests different drawing operations as well as adding custom
+      // operators to the page content.
+
+      const page6 = pdfDoc.addPage([size, size]);
+
+      const text = "These are the test words. "
+      page6.drawText(text + 'regular', {
+        y: size - 20,
+        size: 20,
+        lineHeight: 20,
+        //horizontalScale: 50,
+        //rise: 0,
+        //wordSpace: 10,
+        //characterSpace: -2,
+      });
+      page6.drawText(text + '+5 raised and fontsize 12 instead of 20', {
+        y: size - 20,
+        x: 325,
+        size: 12,
+        lineHeight: 20,
+        //horizontalScale: 50,
+        rise: 5,
+        //wordSpace: 10,
+        //characterSpace: -2,
+      });
+      page6.drawText(text + '50% horizontal scale', {
+        y: size - 40,
+        size: 20,
+        lineHeight: 20,
+        horizontalScale: 50,
+        //rise: 0,
+        //wordSpace: 10,
+        //characterSpace: -2,
+      });
+      page6.drawText(text + '+10 word space', {
+        y: size - 60,
+        size: 20,
+        lineHeight: 20,
+        //horizontalScale: 50,
+        //rise: 0,
+        wordSpace: 10,
+        //characterSpace: -2,
+        renderingMode: TextRenderingMode.Outline,
+      });
+      page6.drawText(text + '+4 character space', {
+        y: size - 80,
+        size: 20,
+        lineHeight: 20,
+        //horizontalScale: 50,
+        //rise: 0,
+        //wordSpace: 10,
+        characterSpace: 4,
+      });
+      page6.drawText(text + 'textRenderingMode = outline', {
+        y: size - 100,
+        size: 20,
+        lineHeight: 20,
+        renderingMode: TextRenderingMode.Outline,
+      });
 
       /********************** Print Metadata **********************/
 

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -14,7 +14,6 @@ import {
   translate,
   LineCapStyle,
   scale,
-  TextRenderingMode,
 } from 'src/api/operators';
 import PDFDocument from 'src/api/PDFDocument';
 import PDFEmbeddedPage from 'src/api/PDFEmbeddedPage';
@@ -977,11 +976,6 @@ export default class PDFPage {
     assertOrUndefined(options.lineHeight, 'options.lineHeight', ['number']);
     assertOrUndefined(options.maxWidth, 'options.maxWidth', ['number']);
     assertOrUndefined(options.wordBreaks, 'options.wordBreaks', [Array]);
-    assertOrUndefined(options.horizontalScale, 'options.horizontalScale', ['number']);
-    assertOrUndefined(options.wordSpace, 'options.wordSpace', ['number']);
-    assertOrUndefined(options.characterSpace, 'options.characterSpace', ['number']);
-    assertOrUndefined(options.rise, 'options.rise', ['number']);
-    assertIsOneOfOrUndefined(options.renderingMode, 'options.renderingMode', TextRenderingMode);
     assertIsOneOfOrUndefined(options.blendMode, 'options.blendMode', BlendMode);
 
     const { oldFont, newFont, newFontKey } = this.setOrEmbedFont(options.font);
@@ -1016,13 +1010,7 @@ export default class PDFPage {
         x: options.x ?? this.x,
         y: options.y ?? this.y,
         lineHeight: options.lineHeight ?? this.lineHeight,
-        // optional:
         graphicsState: graphicsStateKey,
-        horizontalScale: options.horizontalScale, // defaults to 100
-        wordSpace: options.wordSpace, // defaults to 0
-        characterSpace: options.characterSpace, // defaults to 0
-        rise: options.rise, // defaults to 0
-        renderingMode: options.renderingMode, // defaults to TextRenderingMode.Fill
       }),
     );
 

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -14,6 +14,7 @@ import {
   translate,
   LineCapStyle,
   scale,
+  TextRenderingMode,
 } from 'src/api/operators';
 import PDFDocument from 'src/api/PDFDocument';
 import PDFEmbeddedPage from 'src/api/PDFEmbeddedPage';
@@ -976,6 +977,11 @@ export default class PDFPage {
     assertOrUndefined(options.lineHeight, 'options.lineHeight', ['number']);
     assertOrUndefined(options.maxWidth, 'options.maxWidth', ['number']);
     assertOrUndefined(options.wordBreaks, 'options.wordBreaks', [Array]);
+    assertOrUndefined(options.horizontalScale, 'options.horizontalScale', ['number']);
+    assertOrUndefined(options.wordSpace, 'options.wordSpace', ['number']);
+    assertOrUndefined(options.characterSpace, 'options.characterSpace', ['number']);
+    assertOrUndefined(options.rise, 'options.rise', ['number']);
+    assertIsOneOfOrUndefined(options.renderingMode, 'options.renderingMode', TextRenderingMode);
     assertIsOneOfOrUndefined(options.blendMode, 'options.blendMode', BlendMode);
 
     const { oldFont, newFont, newFontKey } = this.setOrEmbedFont(options.font);
@@ -1010,7 +1016,13 @@ export default class PDFPage {
         x: options.x ?? this.x,
         y: options.y ?? this.y,
         lineHeight: options.lineHeight ?? this.lineHeight,
+        // optional:
         graphicsState: graphicsStateKey,
+        horizontalScale: options.horizontalScale, // defaults to 100
+        wordSpace: options.wordSpace, // defaults to 0
+        characterSpace: options.characterSpace, // defaults to 0
+        rise: options.rise, // defaults to 0
+        renderingMode: options.renderingMode, // defaults to TextRenderingMode.Fill
       }),
     );
 

--- a/src/api/PDFPage.ts
+++ b/src/api/PDFPage.ts
@@ -977,11 +977,19 @@ export default class PDFPage {
     assertOrUndefined(options.lineHeight, 'options.lineHeight', ['number']);
     assertOrUndefined(options.maxWidth, 'options.maxWidth', ['number']);
     assertOrUndefined(options.wordBreaks, 'options.wordBreaks', [Array]);
-    assertOrUndefined(options.horizontalScale, 'options.horizontalScale', ['number']);
+    assertOrUndefined(options.horizontalScale, 'options.horizontalScale', [
+      'number',
+    ]);
     assertOrUndefined(options.wordSpace, 'options.wordSpace', ['number']);
-    assertOrUndefined(options.characterSpace, 'options.characterSpace', ['number']);
+    assertOrUndefined(options.characterSpace, 'options.characterSpace', [
+      'number',
+    ]);
     assertOrUndefined(options.rise, 'options.rise', ['number']);
-    assertIsOneOfOrUndefined(options.renderingMode, 'options.renderingMode', TextRenderingMode);
+    assertIsOneOfOrUndefined(
+      options.renderingMode,
+      'options.renderingMode',
+      TextRenderingMode,
+    );
     assertIsOneOfOrUndefined(options.blendMode, 'options.blendMode', BlendMode);
 
     const { oldFont, newFont, newFontKey } = this.setOrEmbedFont(options.font);

--- a/src/api/PDFPageOptions.ts
+++ b/src/api/PDFPageOptions.ts
@@ -1,7 +1,7 @@
 import { Color } from 'src/api/colors';
 import PDFFont from 'src/api/PDFFont';
 import { Rotation } from 'src/api/rotations';
-import { LineCapStyle,TextRenderingMode  } from 'src/api/operators';
+import { LineCapStyle } from 'src/api/operators';
 
 export enum BlendMode {
   Normal = 'Normal',
@@ -32,11 +32,6 @@ export interface PDFPageDrawTextOptions {
   lineHeight?: number;
   maxWidth?: number;
   wordBreaks?: string[];
-  horizontalScale?: number;
-  wordSpace?: number;
-  characterSpace?: number;
-  rise?: number;
-  renderingMode?: TextRenderingMode;
 }
 
 export interface PDFPageDrawImageOptions {

--- a/src/api/PDFPageOptions.ts
+++ b/src/api/PDFPageOptions.ts
@@ -1,7 +1,7 @@
 import { Color } from 'src/api/colors';
 import PDFFont from 'src/api/PDFFont';
 import { Rotation } from 'src/api/rotations';
-import { LineCapStyle } from 'src/api/operators';
+import { LineCapStyle,TextRenderingMode  } from 'src/api/operators';
 
 export enum BlendMode {
   Normal = 'Normal',
@@ -32,6 +32,11 @@ export interface PDFPageDrawTextOptions {
   lineHeight?: number;
   maxWidth?: number;
   wordBreaks?: string[];
+  horizontalScale?: number;
+  wordSpace?: number;
+  characterSpace?: number;
+  rise?: number;
+  renderingMode?: TextRenderingMode;
 }
 
 export interface PDFPageDrawImageOptions {

--- a/src/api/PDFPageOptions.ts
+++ b/src/api/PDFPageOptions.ts
@@ -1,7 +1,7 @@
 import { Color } from 'src/api/colors';
 import PDFFont from 'src/api/PDFFont';
 import { Rotation } from 'src/api/rotations';
-import { LineCapStyle,TextRenderingMode  } from 'src/api/operators';
+import { LineCapStyle, TextRenderingMode } from 'src/api/operators';
 
 export enum BlendMode {
   Normal = 'Normal',

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -31,6 +31,12 @@ import {
   clip,
   endPath,
   appendBezierCurve,
+  TextRenderingMode,
+  setCharacterSpacing, 
+  setHorizontalScaling, 
+  setTextRenderingMode, 
+  setTextRise, 
+  setWordSpacing,
 } from 'src/api/operators';
 import { Rotation, degrees, toRadians } from 'src/api/rotations';
 import { svgPathToOperators } from 'src/api/svgPath';
@@ -47,6 +53,11 @@ export interface DrawTextOptions {
   x: number | PDFNumber;
   y: number | PDFNumber;
   graphicsState?: string | PDFName;
+  horizontalScale?: number | PDFNumber;
+  wordSpace?: number | PDFNumber;
+  characterSpace?: number | PDFNumber;
+  rise?: number | PDFNumber;
+  renderingMode?: TextRenderingMode;
 }
 
 export const drawText = (
@@ -66,6 +77,11 @@ export const drawText = (
       options.x,
       options.y,
     ),
+    options.horizontalScale && setHorizontalScaling(options.horizontalScale),
+    options.wordSpace && setWordSpacing(options.wordSpace),
+    options.characterSpace && setCharacterSpacing(options.characterSpace),
+    options.rise && setTextRise(options.rise),
+    options.renderingMode && setTextRenderingMode(options.renderingMode),
     showText(line),
     endText(),
     popGraphicsState(),
@@ -86,6 +102,11 @@ export const drawLinesOfText = (
     setFillingColor(options.color),
     setFontAndSize(options.font, options.size),
     setLineHeight(options.lineHeight),
+    options.horizontalScale && setHorizontalScaling(options.horizontalScale),
+    options.wordSpace && setWordSpacing(options.wordSpace),
+    options.characterSpace && setCharacterSpacing(options.characterSpace),
+    options.rise && setTextRise(options.rise),
+    options.renderingMode && setTextRenderingMode(options.renderingMode),
     rotateAndSkewTextRadiansAndTranslate(
       toRadians(options.rotate),
       toRadians(options.xSkew),

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -32,10 +32,10 @@ import {
   endPath,
   appendBezierCurve,
   TextRenderingMode,
-  setCharacterSpacing, 
-  setHorizontalScaling, 
-  setTextRenderingMode, 
-  setTextRise, 
+  setCharacterSpacing,
+  setHorizontalScaling,
+  setTextRenderingMode,
+  setTextRise,
   setWordSpacing,
 } from 'src/api/operators';
 import { Rotation, degrees, toRadians } from 'src/api/rotations';

--- a/src/api/operations.ts
+++ b/src/api/operations.ts
@@ -31,12 +31,6 @@ import {
   clip,
   endPath,
   appendBezierCurve,
-  TextRenderingMode,
-  setCharacterSpacing, 
-  setHorizontalScaling, 
-  setTextRenderingMode, 
-  setTextRise, 
-  setWordSpacing,
 } from 'src/api/operators';
 import { Rotation, degrees, toRadians } from 'src/api/rotations';
 import { svgPathToOperators } from 'src/api/svgPath';
@@ -53,11 +47,6 @@ export interface DrawTextOptions {
   x: number | PDFNumber;
   y: number | PDFNumber;
   graphicsState?: string | PDFName;
-  horizontalScale?: number | PDFNumber;
-  wordSpace?: number | PDFNumber;
-  characterSpace?: number | PDFNumber;
-  rise?: number | PDFNumber;
-  renderingMode?: TextRenderingMode;
 }
 
 export const drawText = (
@@ -77,11 +66,6 @@ export const drawText = (
       options.x,
       options.y,
     ),
-    options.horizontalScale && setHorizontalScaling(options.horizontalScale),
-    options.wordSpace && setWordSpacing(options.wordSpace),
-    options.characterSpace && setCharacterSpacing(options.characterSpace),
-    options.rise && setTextRise(options.rise),
-    options.renderingMode && setTextRenderingMode(options.renderingMode),
     showText(line),
     endText(),
     popGraphicsState(),
@@ -102,11 +86,6 @@ export const drawLinesOfText = (
     setFillingColor(options.color),
     setFontAndSize(options.font, options.size),
     setLineHeight(options.lineHeight),
-    options.horizontalScale && setHorizontalScaling(options.horizontalScale),
-    options.wordSpace && setWordSpacing(options.wordSpace),
-    options.characterSpace && setCharacterSpacing(options.characterSpace),
-    options.rise && setTextRise(options.rise),
-    options.renderingMode && setTextRenderingMode(options.renderingMode),
     rotateAndSkewTextRadiansAndTranslate(
       toRadians(options.rotate),
       toRadians(options.xSkew),

--- a/src/api/operators.ts
+++ b/src/api/operators.ts
@@ -213,23 +213,15 @@ export const setFontAndSize = (
   size: number | PDFNumber,
 ) => PDFOperator.of(Ops.SetFontAndSize, [asPDFName(name), asPDFNumber(size)]);
 
-/** @param characterSpace extra space between characters; in unscaled text sapce units; can also be negative **/
 export const setCharacterSpacing = (spacing: number | PDFNumber) =>
   PDFOperator.of(Ops.SetCharacterSpacing, [asPDFNumber(spacing)]);
 
-/**@param wordSpace space "between words" (actually extra space for every ASCII SPACE character); in unscaled text sapce units; can also be negative; NOTE: This only works for fonts that define code 32 (=space) as a single-byte code, according to the standard. (E.g. it works with Helvetica, but not with ubuntuFont.) **/
 export const setWordSpacing = (spacing: number | PDFNumber) =>
   PDFOperator.of(Ops.SetWordSpacing, [asPDFNumber(spacing)]);
 
-/**
- * DEPRECATED: use "setHorizontalScaling" instead 
- * @param squeeze horizontal character spacing */
+/** @param squeeze horizontal character spacing */
 export const setCharacterSqueeze = (squeeze: number | PDFNumber) =>
   PDFOperator.of(Ops.SetTextHorizontalScaling, [asPDFNumber(squeeze)]);
-
-/** @param horizontalScaling horizontal character spacing; value in %; default = 100 **/
-export const setHorizontalScaling = (horizontalScaling: number | PDFNumber) =>
-  PDFOperator.of(Ops.SetTextHorizontalScaling, [asPDFNumber(horizontalScaling)]);
 
 export const setLineHeight = (lineHeight: number | PDFNumber) =>
   PDFOperator.of(Ops.SetTextLineHeight, [asPDFNumber(lineHeight)]);

--- a/src/api/operators.ts
+++ b/src/api/operators.ts
@@ -213,23 +213,27 @@ export const setFontAndSize = (
   size: number | PDFNumber,
 ) => PDFOperator.of(Ops.SetFontAndSize, [asPDFName(name), asPDFNumber(size)]);
 
-/** @param characterSpace extra space between characters; in unscaled text sapce units; can also be negative **/
+/** @param characterSpace extra space between characters; in unscaled text sapce units; can also be negative */
 export const setCharacterSpacing = (spacing: number | PDFNumber) =>
   PDFOperator.of(Ops.SetCharacterSpacing, [asPDFNumber(spacing)]);
 
-/**@param wordSpace space "between words" (actually extra space for every ASCII SPACE character); in unscaled text sapce units; can also be negative; NOTE: This only works for fonts that define code 32 (=space) as a single-byte code, according to the standard. (E.g. it works with Helvetica, but not with ubuntuFont.) **/
+/** @param wordSpace space "between words" (actually extra space for every ASCII SPACE character); in unscaled text sapce units; can also be negative; NOTE: This only works for fonts that define code 32 (=space) as a single-byte code, according to the standard. (E.g. it works with Helvetica, but not with ubuntuFont.) */
 export const setWordSpacing = (spacing: number | PDFNumber) =>
   PDFOperator.of(Ops.SetWordSpacing, [asPDFNumber(spacing)]);
 
 /**
- * DEPRECATED: use "setHorizontalScaling" instead 
- * @param squeeze horizontal character spacing */
+ * DEPRECATED: use "setHorizontalScaling" instead
+ *
+ * @param squeeze horizontal character spacing
+ */
 export const setCharacterSqueeze = (squeeze: number | PDFNumber) =>
   PDFOperator.of(Ops.SetTextHorizontalScaling, [asPDFNumber(squeeze)]);
 
-/** @param horizontalScaling horizontal character spacing; value in %; default = 100 **/
+/** @param horizontalScaling horizontal character spacing; value in %; default = 100 */
 export const setHorizontalScaling = (horizontalScaling: number | PDFNumber) =>
-  PDFOperator.of(Ops.SetTextHorizontalScaling, [asPDFNumber(horizontalScaling)]);
+  PDFOperator.of(Ops.SetTextHorizontalScaling, [
+    asPDFNumber(horizontalScaling),
+  ]);
 
 export const setLineHeight = (lineHeight: number | PDFNumber) =>
   PDFOperator.of(Ops.SetTextLineHeight, [asPDFNumber(lineHeight)]);

--- a/src/api/operators.ts
+++ b/src/api/operators.ts
@@ -213,15 +213,23 @@ export const setFontAndSize = (
   size: number | PDFNumber,
 ) => PDFOperator.of(Ops.SetFontAndSize, [asPDFName(name), asPDFNumber(size)]);
 
+/** @param characterSpace extra space between characters; in unscaled text sapce units; can also be negative **/
 export const setCharacterSpacing = (spacing: number | PDFNumber) =>
   PDFOperator.of(Ops.SetCharacterSpacing, [asPDFNumber(spacing)]);
 
+/**@param wordSpace space "between words" (actually extra space for every ASCII SPACE character); in unscaled text sapce units; can also be negative; NOTE: This only works for fonts that define code 32 (=space) as a single-byte code, according to the standard. (E.g. it works with Helvetica, but not with ubuntuFont.) **/
 export const setWordSpacing = (spacing: number | PDFNumber) =>
   PDFOperator.of(Ops.SetWordSpacing, [asPDFNumber(spacing)]);
 
-/** @param squeeze horizontal character spacing */
+/**
+ * DEPRECATED: use "setHorizontalScaling" instead 
+ * @param squeeze horizontal character spacing */
 export const setCharacterSqueeze = (squeeze: number | PDFNumber) =>
   PDFOperator.of(Ops.SetTextHorizontalScaling, [asPDFNumber(squeeze)]);
+
+/** @param horizontalScaling horizontal character spacing; value in %; default = 100 **/
+export const setHorizontalScaling = (horizontalScaling: number | PDFNumber) =>
+  PDFOperator.of(Ops.SetTextHorizontalScaling, [asPDFNumber(horizontalScaling)]);
 
 export const setLineHeight = (lineHeight: number | PDFNumber) =>
   PDFOperator.of(Ops.SetTextLineHeight, [asPDFNumber(lineHeight)]);


### PR DESCRIPTION
<!-- 
👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇
👉 🚨 Do not remove or skip any sections in this template ⛔️ 👈
👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆

Thank you for taking the time to make a PR! 💖 
Please fill out this template completely to help us provide a prompt review. 😃
You can add more sections if you like. ✅
-->

## What?
The pdf specification allows several text state operators, e.g. for the font, size (Tf) and the line distance (leading, TL). However, there are some more (text rise, horiztontal scaling, word spacing, character spacing, text rendering mode) and I want to make use especially of the horizontalScaling (Tz). I saw that in the OperatorNames actually all were already defined, but not provided to the user (e.g. in drawText) yet. Therefore, I extended everything needed so that all text state operators can be set in the options for drawText. All those operators are implemented to be written only if the option is actually set, i.e. no default values are written to pdf, which would make the file unnecessarily larger.
Example:
`page.drawText('hello world', {
    y: size - 40,
    size: 20,
    lineHeight: 20,
    horizontalScale: 50,
    rise: 5,
    wordSpace: 10,
    renderingMode: TextRenderingMode.Outline,
    characterSpace: 4,
  });`

## Why?
I will need horizontal text scaling. Other users might want to use this or any of the other 4 added text state operators (word spacing, character spacing, text rise, text rendering mode) as well.

## How?
It is implemented in the exact sam way as setting the font (Tf) or the lineHeight (TL). It is the most logic implementation and follows the present code structure. The horizontal spacing was actually already implemented not just in OperatorNames, but also the operator was already written in the name of "setCharacterSqueeze". In my opinion, it would be nicer if the operator would use the name as in the standard (i.e. setHorizontalScaling), as it is the case for all the other operators I have looked at. Therefore, created an additional operator "setHorizontalScaling", but kept the old "setCharacterSqueeze" one for backwards compatibility (with a deprecated note in the docstring). (Note: setCharacterSqueeze was used neither in the code nor in the tests (at least not uncommented), but users might by using it "the hard way", bypassing the "drawText"-function. 

## Testing?
Yes. 
Unit tests: All pass. 
Integration tests: added a page in test 1 with the new options. All pass. pdf looks ok in Adobe, Foxit, Chrome, Firefox.
Linting successful. 
Typecheck successful.

The changes to the code can hardly have an impact to any existing code, since it only extends the existing part. The added options are working as they should, which can be seen in the last page of test1.

## New Dependencies?
No.

## Screenshots
N/A

## Suggested Reading?
Yes

## Anything Else?
I did not add any unit tests, since there were no unit tests for the other text state operators and I haven't created any unit tests so far (being just a hobby coder). For this reason, I could not just create an analogous test for the added text state options. 

## Checklist
- [X] I read [CONTRIBUTING.md](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md).
- [X] I read [MAINTAINERSHIP.md#pull-requests](https://github.com/Hopding/pdf-lib/blob/master/docs/MAINTAINERSHIP.md#pull-requests).
- [ ] I added/updated unit tests for my changes.
- [X] I added/updated integration tests for my changes.
- [X] I [ran the integration tests](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-integration-tests).
- [X] I tested my changes in Node, Deno, and the browser.
- [X] I viewed documents produced with my changes in Adobe Acrobat, Foxit Reader, Firefox, and Chrome.
- [X] I added/updated doc comments for any new/modified public APIs.
- [ ] My changes work for both **new** and **existing** PDF files.
- [X] I [ran the linter](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-linter) on my changes.
