### PR TITLE
JpegEmbedder: Support Buffers that have data in their backing buffer is offset 

### DIFF
--- a/src/core/embedders/JpegEmbedder.ts
+++ b/src/core/embedders/JpegEmbedder.ts
@@ -29,7 +29,11 @@ const ChannelToColorSpace: { [idx: number]: ColorSpace | undefined } = {
  */
 class JpegEmbedder {
   static async for(imageData: Uint8Array) {
-    const dataView = new DataView(imageData.buffer);
+    const dataView = new DataView(
+      imageData.buffer,
+      imageData.byteOffset,
+      imageData.byteLength,
+    );
 
     const soi = dataView.getUint16(0);
     if (soi !== 0xffd8) throw new Error('SOI not found in JPEG');

--- a/tests/core/embedders/JpegEmbedder.spec.ts
+++ b/tests/core/embedders/JpegEmbedder.spec.ts
@@ -59,4 +59,17 @@ describe(`JpegEmbedder`, () => {
     expect(embedder.width).toBe(500);
     expect(embedder.colorSpace).toBe('DeviceCMYK');
   });
+
+  it(`can extract properties of JPEG images have offset backing buffers`, async () => {
+    // This can happen with buffers that are pooled or sprite sheets
+    const oddCmykJpg = Buffer.alloc(10 + cmykJpg.byteLength);
+    cmykJpg.copy(oddCmykJpg, 10);
+    const oddCmykJpgView = oddCmykJpg.subarray(10);
+    const embedder = await JpegEmbedder.for(oddCmykJpgView);
+
+    expect(embedder.bitsPerComponent).toBe(8);
+    expect(embedder.height).toBe(333);
+    expect(embedder.width).toBe(500);
+    expect(embedder.colorSpace).toBe('DeviceCMYK');
+  });
 });


### PR DESCRIPTION
<!-- 
👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇
👉 🚨 Do not remove or skip any sections in this template ⛔️ 👈
👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆

Thank you for taking the time to make a PR! 💖 
Please fill out this template completely to help us provide a prompt review. 😃
You can add more sections if you like. ✅
-->

## What?
<!-- Describe what your PR does. Include code snippets demonstrating how to use any APIs you added/updated. -->
This adds support when the jpeg image data in the backing buffer for a `Buffer` is offset from index 0. 

## Why?
<!-- Describe why you created this PR. Explain why others would find it useful. -->
Buffer.buffer isn't necessarily indexed the same as the Buffer.

Ran into this when some transparent optimization caused a single buffer to be used for multiple short hardcoded test image/non-image Buffers.
https://stackoverflow.com/a/50118846 talks about it, the gist of it that Buffer.from can call Buffer.allocUnsafe which may reuse memory from a pool, so image data can be stored in the middle of the buffer.

Someone could deliberately do this too with something like a sprite sheet.
## How?
<!-- Describe how your PR works. Did you consider any alternative implementations? -->
DataView already supports handling this and Uint8Array has the necessary offset/length fields, so added them to the DataView constructor.

## Testing?
<!-- Describe how you tested your PR. Why are you confident it is correct? -->
Wrote a new test, failed before change, passed after, existing tests pass, scope of the change is very small.
Only ran the nodejs and browser integration tests.

## New Dependencies?
<!-- 
If you added a new dependency then please read https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#adding-dependencies and then:
  * Clearly explain why it is necessary.
  * Explain how you know it is well tested.
  * Explain how you know it is well documented.
  * Explain how you know it is actively supported.
  * State how much it will increase pdf-lib's bundle size.
  * State how you know it will work in all JS environments.
If you did not add a new dependency, simply state "No".
-->
No

## Screenshots
<!-- If your changes can affect the visual appearance of a PDF, then provide screenshots demonstrating this. Otherwise state "N/A".  -->
N/A

## Suggested Reading?
<!-- 
Have you read the PDF specification sections recommended in https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#understanding-pdfs? 
State "Yes" or "No".
-->
https://nodejs.org/dist/latest-v10.x/docs/api/buffer.html#buffer_class_method_buffer_allocunsafe_size

## Anything Else?
<!-- Please share any additional notes here. -->

## Checklist
- [x] I read [CONTRIBUTING.md](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md).
- [x] I read [MAINTAINERSHIP.md#pull-requests](https://github.com/Hopding/pdf-lib/blob/master/docs/MAINTAINERSHIP.md#pull-requests).
- [x] I added/updated unit tests for my changes.
- [ ] I added/updated integration tests for my changes.
- [ ] I [ran the integration tests](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-integration-tests).
- [ ] I tested my changes in Node, Deno, and the browser.
- [ ] I viewed documents produced with my changes in Adobe Acrobat, Foxit Reader, Firefox, and Chrome.
- [ ] I added/updated doc comments for any new/modified public APIs.
- [x] My changes work for both **new** and **existing** PDF files.
- [x] I [ran the linter](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-linter) on my changes.
