### PR TITLE
Remove examples that suggest getting type from `field.constructor.name`

### DIFF
--- a/src/api/PDFDocument.ts
+++ b/src/api/PDFDocument.ts
@@ -244,9 +244,8 @@ export default class PDFDocument {
    * const form = pdfDoc.getForm()
    * const fields = form.getFields()
    * fields.forEach(field => {
-   *   const type = field.constructor.name
    *   const name = field.getName()
-   *   console.log(`${type}: ${name}`)
+   *   console.log(`fieldName: ${name}`)
    * })
    * ```
    * @returns The form for this document.

--- a/src/api/form/PDFForm.ts
+++ b/src/api/form/PDFForm.ts
@@ -131,9 +131,8 @@ export default class PDFForm {
    * const form = pdfDoc.getForm()
    * const fields = form.getFields()
    * fields.forEach(field => {
-   *   const type = field.constructor.name
    *   const name = field.getName()
-   *   console.log(`${type}: ${name}`)
+   *   console.log(`fieldName: ${name}`)
    * })
    * ```
    * @returns An array of all fields in this form.


### PR DESCRIPTION
<!-- 
👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇
👉 🚨 Do not remove or skip any sections in this template ⛔️ 👈
👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆

Thank you for taking the time to make a PR! 💖 
Please fill out this template completely to help us provide a prompt review. 😃
You can add more sections if you like. ✅
-->

## What?

This PR remove some code-comment examples that suggest getting type of a PDF field via `field.constructor.name`.

## Why?

It is not safe/stable to rely on `.constructor.name` in general because minification will mangle the names of constructor functions (to make them as short as possible).

This has confused several folks before, as seen in these issues:
https://github.com/Hopding/pdf-lib/issues/736
https://github.com/Hopding/pdf-lib/issues/755
https://github.com/Hopding/pdf-lib/issues/933
https://github.com/Hopding/pdf-lib/issues/1089

As such, I think we should remove these examples from the codebase.

## How?

I've simply removed the code that uses `.constructor.name` from these examples

## Testing?

No testing is necessary for this PR since it only modifies two code comments.

## New Dependencies?

No.

## Screenshots

N/A

## Suggested Reading?

No, but the reading is not relevant for this PR since it only modifies two code comments.

## Anything Else?

No

## Checklist
- [x] I read [CONTRIBUTING.md](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md).
- [x] I read [MAINTAINERSHIP.md#pull-requests](https://github.com/Hopding/pdf-lib/blob/master/docs/MAINTAINERSHIP.md#pull-requests).

The rest of the checklist is not relevant for this PR since it only modifies two code comments.
- [x] ~I added/updated unit tests for my changes.~
- [x] ~I added/updated integration tests for my changes.~
- [x] ~I [ran the integration tests](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-integration-tests).~
- [x] ~I tested my changes in Node, Deno, and the browser.~
- [x] ~I viewed documents produced with my changes in Adobe Acrobat, Foxit Reader, Firefox, and Chrome.~
- [x] ~I added/updated doc comments for any new/modified public APIs.~
- [x] ~My changes work for both **new** and **existing** PDF files.~
- [x] ~I [ran the linter](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-linter) on my changes.~
