### PR TITLE
Make pdf-lib more graceful like other pdf software

### DIFF
--- a/src/api/form/PDFForm.ts
+++ b/src/api/form/PDFForm.ts
@@ -705,7 +705,7 @@ export default class PDFForm {
     return this.defaultFontCache.access();
   }
 
-  private findWidgetPage(widget: PDFWidgetAnnotation): PDFPage {
+  private findWidgetPage(widget: PDFWidgetAnnotation): PDFPage | undefined {
     const pageRef = widget.P();
     let page = this.doc.getPages().find((x) => x.ref === pageRef);
     if (page === undefined) {

--- a/src/api/form/PDFForm.ts
+++ b/src/api/form/PDFForm.ts
@@ -548,6 +548,9 @@ export default class PDFForm {
       for (let j = 0, lenWidgets = widgets.length; j < lenWidgets; j++) {
         const widget = widgets[j];
         const page = this.findWidgetPage(widget);
+        if (page === undefined) {
+          continue;
+        }
         const widgetRef = this.findWidgetAppearanceRef(field, widget);
 
         const xObjectKey = page.node.newXObject('FlatWidget', widgetRef);
@@ -587,6 +590,10 @@ export default class PDFForm {
       const widgetRef = this.findWidgetAppearanceRef(field, widget);
 
       const page = this.findWidgetPage(widget);
+      if (page === undefined) {
+        continue;
+      }
+
       pages.add(page);
 
       page.node.removeAnnot(widgetRef);
@@ -709,8 +716,13 @@ export default class PDFForm {
 
       page = this.doc.findPageForAnnotationRef(widgetRef);
 
+      /*
+       * In some broken PDF's there may be widgets that don't exist on any page.
+       * We used to throw an error in such cases but it appears that other
+       * PDF readers just ignore such PDF's.
+       */
       if (page === undefined) {
-        throw new Error(`Could not find page for PDFRef ${widgetRef}`);
+        return undefined;
       }
     }
 


### PR DESCRIPTION
Some broken fields may include annotations in their Kids array that couldn't be found on any pages. Up until now we've been throwing an exception when dealing with such fields. But it appears that other PDF software are more resilient to this and gracefully ignore them.

This commit ensures we'll do the same.

Fixes #967,#1281,#1349

<!-- 
👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇👇
👉 🚨 Do not remove or skip any sections in this template ⛔️ 👈
👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆👆

Thank you for taking the time to make a PR! 💖 
Please fill out this template completely to help us provide a prompt review. 😃
You can add more sections if you like. ✅
-->

## What?
<!-- Describe what your PR does. Include code snippets demonstrating how to use any APIs you added/updated. -->

PDF Fields can have `Kids` in them, each `Kid` being a `WidgetAnnotation`. In some rare cases (probably due to bad pdf generators) there are cases that there is a `PDFField` with a an annotation in it `Kids` but that annotation doesn't exist on any page. Therefore we don't know on which page it must be rendered.

## Why?

`PDFForm.findPageForAnnotationRe` is responsible for finding the page for a given annotation. Up until now it'd throw an exception if it couldn't find a page.

This means when trying to flatten such PDF's, pdf-lib would throw an error. So basically you have a pdf file that can be opened up with Chrome, Firefox/pdfjs, Acrobat Reader and even pdf-lib. But trying to flatten it using pdf-lib would cause an exception (as seen in #967,#1281,#1349)

## How?

This patch makes pdf-lib's Flatten gracefully ignore such cases and render the PDF like other pdf readers.

## Testing?

## Checklist
- [x] I read [CONTRIBUTING.md](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md).
- [x] I read [MAINTAINERSHIP.md#pull-requests](https://github.com/Hopding/pdf-lib/blob/master/docs/MAINTAINERSHIP.md#pull-requests).
- [ ] I added/updated unit tests for my changes.
- [ ] I added/updated integration tests for my changes.
- [x] I [ran the integration tests](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-integration-tests).
- [x] I tested my changes in Node, Deno, and the browser.
- [x] I viewed documents produced with my changes in Adobe Acrobat, Foxit Reader, Firefox, and Chrome.
- [x] I added/updated doc comments for any new/modified public APIs.
- [x] My changes work for both **new** and **existing** PDF files.
- [x] I [ran the linter](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-linter) on my changes.
