### PR TITLE
Fix Set Producer metadata on saved document when provided

### DIFF
--- a/src/api/PDFDocument.ts
+++ b/src/api/PDFDocument.ts
@@ -1339,9 +1339,9 @@ export default class PDFDocument {
 
     const info = this.getInfoDict();
 
-    this.setProducer(pdfLib);
     this.setModificationDate(now);
 
+    if (!info.get(PDFName.of('Producer'))) this.setProducer(pdfLib);
     if (!info.get(PDFName.of('Creator'))) this.setCreator(pdfLib);
     if (!info.get(PDFName.of('CreationDate'))) this.setCreationDate(now);
   }

--- a/tests/api/PDFDocument.spec.ts
+++ b/tests/api/PDFDocument.spec.ts
@@ -258,14 +258,17 @@ describe(`PDFDocument`, () => {
       pdfDoc.setCreationDate(creationDate);
       pdfDoc.setModificationDate(modificationDate);
 
-      expect(pdfDoc.getTitle()).toBe(title);
-      expect(pdfDoc.getAuthor()).toBe(author);
-      expect(pdfDoc.getSubject()).toBe(subject);
-      expect(pdfDoc.getProducer()).toBe(producer);
-      expect(pdfDoc.getCreator()).toBe(creator);
-      expect(pdfDoc.getKeywords()).toBe(keywords.join(' '));
-      expect(pdfDoc.getCreationDate()).toStrictEqual(creationDate);
+      const savedPdfDoc = await PDFDocument.load(await pdfDoc.save())
+      expect(savedPdfDoc.getTitle()).toBe(title);
+      expect(savedPdfDoc.getAuthor()).toBe(author);
+      expect(savedPdfDoc.getSubject()).toBe(subject);
+      expect(savedPdfDoc.getProducer()).toBe(producer);
+      expect(savedPdfDoc.getCreator()).toBe(creator);
+      expect(savedPdfDoc.getKeywords()).toBe(keywords.join(' '));
+      expect(savedPdfDoc.getCreationDate()).toStrictEqual(creationDate);
+      
       expect(pdfDoc.getModificationDate()).toStrictEqual(modificationDate);
+      expect(savedPdfDoc.getModificationDate()).not.toEqual(modificationDate);
     });
 
     it(`they can retrieve the title, author, subject, producer, creator, and keywords from an existing document`, async () => {


### PR DESCRIPTION
## What?
When provided, `Producer` info is stored in the saved document.

## Why?
`Producer` info was getting overwritten before saving the document, even when `setProducer` was called before.

## How?
Modified `PDFDocument.ts` to use the default value for `Producer` only when this information was not provided or updated using `setProducer`. 

## Testing?
PDFDocument unit test updated to cover this scenario.

## Screenshots
N/A

## Suggested Reading?
Yes

## Anything Else?
N/A

## Checklist
- [ ] I read [CONTRIBUTING.md](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md).
- [ ] I read [MAINTAINERSHIP.md#pull-requests](https://github.com/Hopding/pdf-lib/blob/master/docs/MAINTAINERSHIP.md#pull-requests).
- [ ] I added/updated unit tests for my changes.
- [ ] I added/updated integration tests for my changes.
- [ ] I [ran the integration tests](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-integration-tests).
- [ ] I tested my changes in Node, Deno, and the browser.
- [ ] I viewed documents produced with my changes in Adobe Acrobat, Foxit Reader, Firefox, and Chrome.
- [ ] I added/updated doc comments for any new/modified public APIs.
- [ ] My changes work for both **new** and **existing** PDF files.
- [ ] I [ran the linter](https://github.com/Hopding/pdf-lib/blob/master/docs/CONTRIBUTING.md#running-the-linter) on my changes.
